### PR TITLE
Comment/admin profile cleanup: AdminProfileRequest 불필요 import 제거 및 주석 정리

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/request/AdminProfileRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/request/AdminProfileRequest.java
@@ -1,8 +1,5 @@
 package ready_to_marry.authservice.admin.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.UUID;
@@ -27,6 +24,6 @@ public class AdminProfileRequest {
     // 관리자 소속 부서명
     private String department;
 
-    // 관리자 연락처: 맨 앞에 + 가 0~1회 올 수 있고 그 뒤에는 숫자나 하이픈만 조합
+    // 관리자 연락처
     private String phone;
 }


### PR DESCRIPTION
이전 PR(#4)에서 피드백 반영하여 불필요 import 삭제 및 주석 정리만 남겼습니다.

## 🔥 개요 (Purpose)
- AdminProfileRequest DTO에서 사용되지 않는 import 문을 제거하고, 필드 설명 주석을 간결하게 수정했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- AdminProfileRequest 클래스에서 더 이상 사용되지 않는 import 문 삭제
- phone 필드 설명 주석을 간결하게 수정

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- DTO 로직이나 API 동작에는 영향이 없으며, 순수하게 주석 및 import 정리만 포함
- 이후 기능 개발 브랜치와 독립적으로 머지