### PR TITLE
Refactor/common exception and comments: NotFound 핸들러 수정 및 GlobalExceptionHandler, ErrorDetail 주석 개선 

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/common/dto/response/ErrorDetail.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/dto/response/ErrorDetail.java
@@ -3,7 +3,7 @@ package ready_to_marry.authservice.common.dto.response;
 import lombok.*;
 
 /**
- * 비즈니스 오류 발생 시 필드별 상세 메시지
+ * 검증 오류 발생 시 필드별 상세 메시지
  *
  * - field  : 오류가 발생한 필드 이름
  * - reason : 해당 필드의 오류 사유

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/exception/GlobalExceptionHandler.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     /**
      * 비즈니스 오류 예외 처리
      * HTTP 200 + code>0
-     * code = (1000~1999)
+     * code = (1300~1399)
      * */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusiness(BusinessException ex) {
@@ -117,7 +117,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleNotFound(RuntimeException ex) {
         ApiResponse<Void> body = ApiResponse.<Void>builder()
                 .code(404)
-                .message("Not Found")
+                .message(ex.getMessage())
                 .data(null)
                 .build();
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
@@ -126,7 +126,7 @@ public class GlobalExceptionHandler {
     /**
      * 인프라(시스템) 오류 예외 처리
      * HTTP 500 + code>0
-     * code = (2000~2999)
+     * code = (2300~2399)
      */
     @ExceptionHandler(InfrastructureException.class)
     public ResponseEntity<ApiResponse<Void>> handleInfrastructure(InfrastructureException ex) {


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- GlobalExceptionHandler의 NotFound 핸들러 응답 메시지를 고정 "Not Found"에서 예외 메시지인 ex.getMessage()로 변경하고, GlobalExceptionHandler, ErrorDetail 주석을 정비했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- GlobalExceptionHandler.handleNotFound
   - 기존에 모든 404 응답 메시지를 "Not Found"로 고정하던 부분을, 실제 발생한 예외의 메시지(ex.getMessage())로 내려주도록 수정
  
- 주석 개선
   - GlobalExceptionHandler 클래스의 비즈니스 오류 예외 처리, 인프라(시스템) 오류 예외 처리 주석을 수정
   - 검증 오류 상세 정보를 담는 ErrorDetail 클래스의 주석을 수정

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)