### PR TITLE
Comment/add throws javadoc partner approval: JsonUtil 및 PartnerApprovalService Javadoc에 예외 주석 추가

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
@@ -1,6 +1,8 @@
 package ready_to_marry.authservice.admin.service;
 
 import ready_to_marry.authservice.admin.dto.request.PartnerRejectionRequest;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
 
 import java.util.UUID;
 
@@ -14,6 +16,9 @@ public interface PartnerApprovalService {
      * 2) auth_account에 status 업데이트 (PENDING_ADMIN_APPROVAL -> ACTIVE)
      *
      * @param accountId 승인 대상 계정의 UUID
+     * @throws BusinessException        PENDING_ADMIN_APPROVAL_REQUIRED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void approvePartner(UUID accountId);
 
@@ -27,6 +32,11 @@ public interface PartnerApprovalService {
      *
      * @param accountId 거부 대상 계정의 UUID
      * @param request 관리자 파트너 승인 거절 요청 DTO
+     * @throws BusinessException        PENDING_ADMIN_APPROVAL_REQUIRED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     * @throws InfrastructureException  DB_DELETE_FAILURE
+     * @throws InfrastructureException JSON_SERIALIZATION_FAILURE
      */
     void rejectPartner(UUID accountId, PartnerRejectionRequest request);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/util/JsonUtil.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/util/JsonUtil.java
@@ -20,6 +20,8 @@ public final class JsonUtil {
 
     /**
      * 객체를 JSON 문자열로 직렬화
+     *
+     * @throws InfrastructureException JSON_SERIALIZATION_FAILURE
      */
     public static String toJson(Object obj) {
         try {


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- JsonUtil.toJson 메서드와 PartnerApprovalService 인터페이스에 Javadoc @throws 태그를 추가하여 예외 상황을 명시적으로 작성했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [X] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- JsonUtil.toJson Javadoc에 @throws InfrastructureException 주석을 추가
- PartnerApprovalService의 approvePartner 및 rejectPartner 메서드 Javadoc에 @throws 예외 주석을 추가

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)