### PR TITLE
Feat/social auth: OAuth2 소셜 로그인 및 프로필 완성 → 유저 회원가입·로그인 기능 구현

### DIFF
--- a/AuthService/build.gradle
+++ b/AuthService/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     // Web & Actuator
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Retry & AOP
     implementation 'org.springframework.retry:spring-retry'
@@ -44,7 +45,7 @@ dependencies {
 
     // Database (JPA + PostgreSQL)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly     'org.postgresql:postgresql:42.2.5'
+    runtimeOnly    'org.postgresql:postgresql:42.2.5'
 
     // Key-Value Store (Redis)
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
@@ -43,6 +43,15 @@ public interface AccountService {
     void updatePartnerId(UUID accountId, Long partnerId);
 
     /**
+     * 계정에 연결된 userId, status 업데이트
+     *
+     * @param accountId 계정의 UUID
+     * @param userId 유저 서비스의 식별자
+     * @param status 적용할 AccountStatus
+     */
+    void updateUserIdAndStatus(UUID accountId, Long userId, AccountStatus status);
+
+    /**
      * 계정 상태 업데이트
      *
      * @param accountId 계정의 UUID

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
@@ -2,7 +2,6 @@ package ready_to_marry.authservice.account.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ready_to_marry.authservice.account.entity.AuthAccount;
@@ -12,7 +11,6 @@ import ready_to_marry.authservice.common.enums.AccountStatus;
 import java.util.Optional;
 import java.util.UUID;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 class AccountServiceImpl implements AccountService {
@@ -40,22 +38,25 @@ class AccountServiceImpl implements AccountService {
     @Transactional
     public void updatePartnerId(UUID accountId, Long partnerId) {
         AuthAccount account = authAccountRepository.findById(accountId)
-                .orElseThrow(() -> {
-                    log.error("Account not found: identifierType=accountId, identifierValue={}", accountId);
-                    return new EntityNotFoundException("Account not found");
-                });
+                .orElseThrow(() -> new EntityNotFoundException("Account(" + accountId + ") not found"));
 
         account.setPartnerId(partnerId);
     }
 
     @Override
     @Transactional
+    public void updateUserIdAndStatus(UUID accountId, Long userId, AccountStatus status) {
+        AuthAccount account = authAccountRepository.findById(accountId)
+                .orElseThrow(() -> new EntityNotFoundException("Account(" + accountId + ") not found"));
+        account.setUserId(userId);
+        account.setStatus(status);
+    }
+
+    @Override
+    @Transactional
     public void updateStatus(UUID accountId, AccountStatus status) {
         AuthAccount account = authAccountRepository.findById(accountId)
-                .orElseThrow(() -> {
-                    log.error("Account not found: identifierType=accountId, identifierValue={}", accountId);
-                    return new EntityNotFoundException("Account not found");
-                });
+                .orElseThrow(() -> new EntityNotFoundException("Account(" + accountId + ") not found"));
 
         account.setStatus(status);
     }

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
@@ -50,7 +50,9 @@ public class SecurityConfig {
                         // Auth Service 인증 엔드포인트만 모두 허용
                         .requestMatchers(
                                 // FIXME: 임시로 로그인 및 회원가입 엔드포인트 추가함. 실제 엔드포인트로 변경 필요
-                                "/auth/users/oauth2",
+                                "/auth/oauth2/authorize/**",
+                                "/auth/oauth2/callback/**",
+                                "/auth/users/profile/complete",
                                 "/auth/partners/login",
                                 "/auth/partners/signup",
                                 "/auth/partners/verify",

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/config/WebClientConfig.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package ready_to_marry.authservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/exception/ErrorCode.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/exception/ErrorCode.java
@@ -13,6 +13,10 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED(1304, "Email not verified"),
     PENDING_ADMIN_APPROVAL(1305, "Pending admin approval"),
     PENDING_ADMIN_APPROVAL_REQUIRED(1306, "Pending admin approval status required"),
+    PROVIDER_NOT_SUPPORTED(1307, "Unsupported OAuth2 provider"),
+    INVALID_OAUTH2_STATE(1308, "Invalid OAuth2 state"),
+    ACCOUNT_NOT_FOUND(1309, "Account not found"),
+    PROFILE_ALREADY_COMPLETED(1310, "User profile is already completed"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2301, "System error occurred while saving data to the database"),
@@ -23,7 +27,12 @@ public enum ErrorCode {
     VERIFICATION_TOKEN_DELETE_FAILURE(2306, "System error occurred while deleting verification token from redis"),
     VERIFICATION_TOKEN_RETRIEVE_FAILURE(2307, "System error occurred while retrieving verification token from redis"),
     EMAIL_SEND_FAILURE(2308, "System error occurred while sending verification email"),
-    JSON_SERIALIZATION_FAILURE(2309, "System error occurred while serializing object to JSON");
+    JSON_SERIALIZATION_FAILURE(2309, "System error occurred while serializing object to JSON"),
+    PKCE_CHALLENGE_GENERATION_FAILURE(2310, "System error occurred while generating PKCE code_challenge"),
+    OAUTH_STATE_SAVE_FAILURE(2311, "System error occurred while saving OAuth state"),
+    OAUTH_STATE_RETRIEVE_REMOVE_FAILURE(2312, "System error occurred while retrieving or removing OAuth state"),
+    OAUTH_TOKEN_EXCHANGE_FAILURE(2313, "System error occurred while exchanging OAuth token"),
+    OAUTH_USERINFO_FAILURE(2314, "System error occurred while fetching user info from OAuth provider");
 
     private final int code;
     private final String message;

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/util/MaskingUtil.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/util/MaskingUtil.java
@@ -54,4 +54,66 @@ public final class MaskingUtil {
         String maskedMiddle = "*".repeat(token.length() - 2 * unmasked);
         return prefix + maskedMiddle + suffix;
     }
+
+    /**
+     * verifier 문자열 부분 마스킹
+     */
+    public static String maskVerifier(String verifier) {
+        if (verifier == null || verifier.length() < 8) {
+            return "****";
+        }
+        String prefix = verifier.substring(0, 4);
+        String suffix = verifier.substring(verifier.length() - 4);
+        return prefix + "..." + suffix;
+    }
+
+    /**
+     * state 문자열 부분 마스킹
+     */
+    public static String maskState(String state) {
+        if (state == null || state.length() < 8) {
+            return "****";
+        }
+        String prefix = state.substring(0, 4);
+        String suffix = state.substring(state.length() - 4);
+        return prefix + "..." + suffix;
+    }
+
+    /**
+     * code 문자열 부분 마스킹
+     */
+    public static String maskCode(String code) {
+        if (code == null || code.length() < 4) {
+            return "****";
+        }
+        String prefix = code.substring(0, 2);
+        String suffix = code.substring(code.length() - 2);
+        return prefix + "..." + suffix;
+    }
+
+    /**
+     * 소셜 로그인 형태의 loginId를 부분 마스킹
+     * 예: "kakao|123456789" → "kakao|12*****89"
+     */
+    public static String maskSocialLoginId(String socialLoginId) {
+        if (socialLoginId == null || !socialLoginId.contains("|")) {
+            return "****";
+        }
+
+        String[] parts = socialLoginId.split("\\|", 2);
+        String provider = parts[0];
+        String userId = parts[1];
+
+        String maskedUserId;
+        if (userId == null || userId.length() <= 4) {
+            maskedUserId = "*".repeat(userId.length());
+        } else {
+            String prefix = userId.substring(0, 2);
+            String suffix = userId.substring(userId.length() - 2);
+            String masked = "*".repeat(userId.length() - 4);
+            maskedUserId = prefix + masked + suffix;
+        }
+
+        return provider + "|" + maskedUserId;
+    }
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/client/GoogleOAuthClientImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/client/GoogleOAuthClientImpl.java
@@ -1,0 +1,127 @@
+package ready_to_marry.authservice.social.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.social.config.OAuthProviderProperties;
+import ready_to_marry.authservice.social.dto.external.OAuth2Token;
+import ready_to_marry.authservice.social.dto.external.SocialUserInfo;
+
+@Slf4j
+@Component("google")
+@RequiredArgsConstructor
+public class GoogleOAuthClientImpl implements SocialOAuthClient {
+    private static final String PROVIDER_NAME = "google";
+
+    private final OAuthProviderProperties oAuthProviderProperties;
+    private final WebClient webClient;
+
+    @Override
+    public String getAuthorizationUrl(String state, String codeChallenge) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        // 2) 인가 요청 URL을 구성하여 반환
+        return UriComponentsBuilder.fromUriString(prop.getAuthUri())
+                .queryParam("response_type", "code")
+                .queryParam("client_id", prop.getClientId())
+                .queryParam("redirect_uri", prop.getRedirectUri())
+                .queryParam("scope", "openid")
+                .queryParam("state", state)
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("code_challenge_method", "S256")
+                .build().toUriString();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public OAuth2Token getToken(String code, String verifier) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.post()
+                // 2) HTTP 요청 데이터 생성
+                // 3) 소셜 인증서버에 액세스 토큰 요청 (HTTP POST)
+                .uri(prop.getTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", prop.getClientId())
+                        .with("client_secret", prop.getClientSecret())
+                        .with("redirect_uri", prop.getRedirectUri())
+                        .with("code", code)
+                        .with("code_verifier", verifier)
+                )
+
+                // 4) 소셜 인증서버로부터 액세스 토큰 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 OAuth2Token 객체로 역직렬화
+                .bodyToMono(OAuth2Token.class)
+
+                // 6) OAuth2Token 객체 반환
+                .block();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public SocialUserInfo getUserInfo(String accessToken) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.get()
+                // 2) HTTP 요청 데이터 생성 (Authorization 헤더에 Bearer 토큰 설정)
+                // 3) 소셜 인증서버에 사용자 정보 요청 (HTTP GET)
+                .uri(prop.getUserInfoUri())
+                .header("Authorization","Bearer " + accessToken)
+
+                // 4) 소셜 인증서버로부터 사용자 정보 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 SocialUserInfo 객체로 역직렬화
+                .bodyToMono(SocialUserInfo.class)
+
+                // 6) SocialUserInfo 객체 반환
+                .block();
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/client/KakaoOAuthClientImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/client/KakaoOAuthClientImpl.java
@@ -1,0 +1,126 @@
+package ready_to_marry.authservice.social.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.social.config.OAuthProviderProperties;
+import ready_to_marry.authservice.social.dto.external.OAuth2Token;
+import ready_to_marry.authservice.social.dto.external.SocialUserInfo;
+
+@Slf4j
+@Component("kakao")
+@RequiredArgsConstructor
+public class KakaoOAuthClientImpl implements SocialOAuthClient {
+    private static final String PROVIDER_NAME = "kakao";
+
+    private final OAuthProviderProperties oAuthProviderProperties;
+    private final WebClient webClient;
+
+    @Override
+    public String getAuthorizationUrl(String state, String codeChallenge) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        // 2) 인가 요청 URL을 구성하여 반환
+        return UriComponentsBuilder.fromUriString(prop.getAuthUri())
+                .queryParam("response_type", "code")
+                .queryParam("client_id", prop.getClientId())
+                .queryParam("redirect_uri", prop.getRedirectUri())
+                .queryParam("state", state)
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("code_challenge_method", "S256")
+                .build().toUriString();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public OAuth2Token getToken(String code, String verifier) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.post()
+                // 2) HTTP 요청 데이터 생성
+                // 3) 소셜 인증서버에 액세스 토큰 요청 (HTTP POST)
+                .uri(prop.getTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", prop.getClientId())
+                        .with("client_secret", prop.getClientSecret())
+                        .with("redirect_uri", prop.getRedirectUri())
+                        .with("code", code)
+                        .with("code_verifier", verifier)
+                )
+
+                // 4) 소셜 인증서버로부터 액세스 토큰 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 OAuth2Token 객체로 역직렬화
+                .bodyToMono(OAuth2Token.class)
+
+                // 6) OAuth2Token 객체 반환
+                .block();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public SocialUserInfo getUserInfo(String accessToken) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.get()
+                // 2) HTTP 요청 데이터 생성 (Authorization 헤더에 Bearer 토큰 설정)
+                // 3) 소셜 인증서버에 사용자 정보 요청 (HTTP GET)
+                .uri(prop.getUserInfoUri())
+                .header("Authorization","Bearer " + accessToken)
+
+                // 4) 소셜 인증서버로부터 사용자 정보 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 SocialUserInfo 객체로 역직렬화
+                .bodyToMono(SocialUserInfo.class)
+
+                // 6) SocialUserInfo 객체 반환
+                .block();
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/client/NaverOAuthClientImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/client/NaverOAuthClientImpl.java
@@ -1,0 +1,125 @@
+package ready_to_marry.authservice.social.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.social.config.OAuthProviderProperties;
+import ready_to_marry.authservice.social.dto.external.OAuth2Token;
+import ready_to_marry.authservice.social.dto.external.SocialUserInfo;
+
+@Slf4j
+@Component("naver")
+@RequiredArgsConstructor
+public class NaverOAuthClientImpl implements SocialOAuthClient {
+    private static final String PROVIDER_NAME = "naver";
+
+    private final OAuthProviderProperties oAuthProviderProperties;
+    private final WebClient webClient;
+
+    @Override
+    public String getAuthorizationUrl(String state, String codeChallenge) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        // 2) 인가 요청 URL을 구성하여 반환
+        return UriComponentsBuilder.fromUriString(prop.getAuthUri())
+                .queryParam("response_type", "code")
+                .queryParam("client_id", prop.getClientId())
+                .queryParam("redirect_uri", prop.getRedirectUri())
+                .queryParam("state", state)
+                // PKCE 미지원: code_challenge 무시, state만 포함
+                .build().toUriString();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public OAuth2Token getToken(String code, String state) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.post()
+                // 2) HTTP 요청 데이터 생성
+                // 3) 소셜 인증서버에 액세스 토큰 요청 (HTTP POST)
+                .uri(prop.getTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", prop.getClientId())
+                        .with("client_secret", prop.getClientSecret())
+                        .with("redirect_uri", prop.getRedirectUri())
+                        .with("code", code)
+                        .with("state", state)
+                )
+
+                // 4) 소셜 인증서버로부터 액세스 토큰 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 OAuth2Token 객체로 역직렬화
+                .bodyToMono(OAuth2Token.class)
+
+                // 6) OAuth2Token 객체 반환
+                .block();
+    }
+
+    @Override
+    // WebClientRequestException 또는 5xx 응답 발생 시, 최대 3회까지 재시도(backoff 2000ms)한 뒤 예외를 전파
+    @Retryable(
+            include = {
+                    WebClientRequestException.class,
+                    WebClientResponseException.InternalServerError.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000)
+    )
+    public SocialUserInfo getUserInfo(String accessToken) {
+        // 1) PROVIDER 설정 정보 조회
+        OAuthProviderProperties.Provider prop = oAuthProviderProperties.getProvider(PROVIDER_NAME);
+
+        if (prop == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), PROVIDER_NAME);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        return webClient.get()
+                // 2) HTTP 요청 데이터 생성 (Authorization 헤더에 Bearer 토큰 설정)
+                // 3) 소셜 인증서버에 사용자 정보 요청 (HTTP GET)
+                .uri(prop.getUserInfoUri())
+                .header("Authorization","Bearer " + accessToken)
+
+                // 4) 소셜 인증서버로부터 사용자 정보 응답 수신
+                .retrieve()
+
+                // 5) 응답 데이터를 SocialUserInfo 객체로 역직렬화
+                .bodyToMono(SocialUserInfo.class)
+
+                // 6) SocialUserInfo 객체 반환
+                .block();
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/client/SocialOAuthClient.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/client/SocialOAuthClient.java
@@ -1,0 +1,56 @@
+package ready_to_marry.authservice.social.client;
+
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.social.dto.external.OAuth2Token;
+import ready_to_marry.authservice.social.dto.external.SocialUserInfo;
+
+/**
+ * OAuth2 소셜 로그인 클라이언트 인터페이스
+ *
+ * 각 소셜 제공자의 OAuth2 인증 과정을 처리
+ * 구현 클래스는 소셜 제공자별로 개별 HTTP 요청·응답 구조를 처리
+ */
+public interface SocialOAuthClient {
+    /**
+     * Provider별 인가 요청 URL 생성
+     * 1) PROVIDER 설정 정보 조회
+     * 2) 인가 요청 URL을 구성하여 반환
+     *
+     * @param state                     CSRF 방지를 위한 state
+     * @param codeChallenge             PKCE code_challenge (PKCE 미지원 프로바이더는 사용안함)
+     * @return String                   인가 요청 URL
+     * @throws BusinessException        PROVIDER_NOT_SUPPORTED
+     */
+    String getAuthorizationUrl(String state, String codeChallenge);
+
+    /**
+     * 인가 코드 → 액세스 토큰 교환
+     * 1) PROVIDER 설정 정보 조회
+     * 2) HTTP 요청 데이터 생성
+     * 3) 소셜 인증서버에 액세스 토큰 요청 (HTTP POST)
+     * 4) 소셜 인증서버로부터 액세스 토큰 응답 수신
+     * 5) 응답 데이터를 OAuth2Token 객체로 역직렬화
+     * 6) OAuth2Token 객체 반환
+     *
+     * @param code                      소셜 인증서버로부터 전달받은 인가 코드(Authorization Code)
+     * @param verifier                  PKCE code_verifier or state (state-only 프로바이더)
+     * @return OAuth2Token              액세스 토큰 및 리프레시 토큰 정보가 담긴 OAuth2Token(DTO)
+     * @throws BusinessException        PROVIDER_NOT_SUPPORTED
+     */
+    OAuth2Token getToken(String code, String verifier);
+
+    /**
+     * 액세스 토큰 → 사용자 정보 조회
+     * 1) PROVIDER 설정 정보 조회
+     * 2) HTTP 요청 데이터 생성 (Authorization 헤더에 Bearer 토큰 설정)
+     * 3) 소셜 인증서버에 사용자 정보 요청 (HTTP GET)
+     * 4) 소셜 인증서버로부터 사용자 정보 응답 수신
+     * 5) 응답 데이터를 SocialUserInfo 객체로 역직렬화
+     * 6) SocialUserInfo 객체 반환
+     *
+     * @param accessToken               소셜 인증서버가 발급한 유효한 액세스 토큰
+     * @return SocialUserInfo           사용자의 소셜 고유 ID를 담고 있는 SocialUserInfo(DTO)
+     * @throws BusinessException        PROVIDER_NOT_SUPPORTED
+     */
+    SocialUserInfo getUserInfo(String accessToken);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/config/OAuthProviderProperties.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/config/OAuthProviderProperties.java
@@ -1,0 +1,41 @@
+package ready_to_marry.authservice.social.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * 소셜 로그인 관련 설정 바인딩 클래스
+ *
+ * - auth.oauth.* 프로퍼티를 매핑
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "auth.oauth")
+public class OAuthProviderProperties {
+    // 각 provider별 설정
+    private Map<String, Provider> providers;
+
+    // PKCE state → verifier 저장 TTL
+    private Duration stateTtl;
+
+    @Getter
+    @Setter
+    public static class Provider {
+        private String clientId;
+        private String clientSecret;
+        private String authUri;
+        private String tokenUri;
+        private String userInfoUri;
+        private String redirectUri;
+    }
+
+    public Provider getProvider(String name) {
+        return providers.get(name);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/controller/OAuth2Controller.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/controller/OAuth2Controller.java
@@ -1,0 +1,87 @@
+package ready_to_marry.authservice.social.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.authservice.common.dto.response.ApiResponse;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.social.dto.SocialLoginResult;
+import ready_to_marry.authservice.social.dto.response.SocialAuthResponse;
+import ready_to_marry.authservice.social.service.OAuth2Service;
+
+/**
+ * 소셜 로그인(PKCE + state) 시작 및 콜백을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/auth/oauth2")
+@RequiredArgsConstructor
+public class OAuth2Controller {
+    private final OAuth2Service oauth2Service;
+
+    /**
+     * 소셜 인증 요청 URL 생성
+     *
+     * @param provider 소셜 로그인 제공자 (예: kakao)
+     * @return 성공 시 code=0, data=authorization URL
+     */
+    @GetMapping("/authorize/{provider}")
+    public ResponseEntity<ApiResponse<String>> authorize(@PathVariable String provider) {
+        // 소셜 로그인 인증 요청 URL을 생성
+        String authUrl = oauth2Service.buildAuthUrl(provider);
+
+        ApiResponse<String> body = ApiResponse.<String>builder()
+                .code(0)
+                .message("Social authentication URL generated")
+                .data(authUrl)
+                .build();
+
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * 소셜 인증 서버 콜백 처리
+     *
+     * @param provider 소셜 로그인 제공자 (예: kakao)
+     * @param code     발급된 인가 코드
+     * @param state    CSRF 방지용 state
+     * @return 성공 시 code=0, data=SocialAuthResponse
+     * - status = INCOMPLETE: data.accountId에 값 세팅 (프론트가 프로필 완성 화면으로 이동)
+     * - status = SUCCESS: data.tokens에 JWT 토큰 정보 세팅 (JWT 토큰 발급 완료)
+     */
+    @GetMapping("/callback/{provider}")
+    public ResponseEntity<ApiResponse<SocialAuthResponse>> callback(@PathVariable String provider, @RequestParam("code")  String code, @RequestParam("state") String state) {
+        // 1) 소셜 인증 서버로부터 받은 인가 코드와 state를 처리하여 소셜 로그인 로그인 또는 2단계 가입 흐름을 수행
+        SocialLoginResult result = oauth2Service.handleCallback(provider, code, state);
+
+        SocialAuthResponse resp;
+        String message;
+        if (result.isProfileIncomplete()) {
+            // 2) 프로필 미완료: accountId만 담아서 응답
+            resp = SocialAuthResponse.builder()
+                    .status(SocialAuthResponse.Status.INCOMPLETE)
+                    .accountId(result.getAccountId())
+                    .build();
+            message = "User profile not completed";
+        } else {
+            // 3) 프로필 완료: JwtResponse로 JWT 토큰 담아서 응답
+            JwtResponse tokens = JwtResponse.builder()
+                    .accessToken(result.getAccessToken())
+                    .refreshToken(result.getRefreshToken())
+                    .expiresIn(result.getExpiresIn())
+                    .build();
+            resp = SocialAuthResponse.builder()
+                    .status(SocialAuthResponse.Status.SUCCESS)
+                    .tokens(tokens)
+                    .build();
+            message = "User login successful";
+        }
+
+        ApiResponse<SocialAuthResponse> body = ApiResponse.<SocialAuthResponse>builder()
+                .code(0)
+                .message(message)
+                .data(resp)
+                .build();
+
+        return ResponseEntity.ok(body);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/dto/SocialLoginResult.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/dto/SocialLoginResult.java
@@ -1,0 +1,54 @@
+package ready_to_marry.authservice.social.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 소셜 로그인 처리 결과를 나타내는 내부 상태 DTO
+ *
+ * 소셜 로그인 시, 계정이 이미 존재하고 프로필이 완료된 경우 → JWT 토큰 발급 (ACTIVE 상태)
+ * 계정이 처음 생성되었거나 프로필이 미완료된 경우 → 프로필 입력 요청 (WAITING_PROFILE_COMPLETION 상태)
+ * JWT 토큰 응답을 내려줄지, 프로필 입력 요청을 보낼지 판단하는 기준으로 사용
+ */
+@Getter
+@RequiredArgsConstructor
+public class SocialLoginResult {
+    // 프로필이 미완료된 상태인지 여부 (true인 경우 프로필 입력이 필요한 상태)
+    private final boolean profileIncomplete;
+
+    //가입된 계정의 식별자 (profileIncomplete=true인 경우 사용)
+    private final UUID accountId;
+
+    // 발급된 액세스 토큰 (profileIncomplete=false인 경우 사용)
+    private final String accessToken;
+
+    // 발급된 리프레시 토큰 (profileIncomplete=false인 경우 사용)
+    private final String refreshToken;
+
+    // 액세스 토큰 만료 시간 (초 단위, profileIncomplete=false인 경우 사용)
+    private final long expiresIn;
+
+    /**
+     * 프로필 미완료 상태 결과 생성
+     *
+     * @param accountId             가입 혹은 조회된 계정 ID
+     * @return SocialLoginResult    프로필 미완료 상태의 로그인 결과 객체
+     */
+    public static SocialLoginResult incomplete(UUID accountId) {
+        return new SocialLoginResult(true, accountId, null, null, 0);
+    }
+
+    /**
+     * 프로필 완료 상태 결과 생성
+     *
+     * @param accessToken           발급된 액세스 토큰
+     * @param refreshToken          발급된 리프레시 토큰
+     * @param expiresIn             액세스 토큰 만료 시간(초)
+     * @return SocialLoginResult    프로필이 완료된 사용자에 대한 로그인 결과 객체
+     */
+    public static SocialLoginResult active(String accessToken, String refreshToken, long expiresIn) {
+        return new SocialLoginResult(false, null, accessToken, refreshToken, expiresIn);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/OAuth2Token.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/OAuth2Token.java
@@ -1,0 +1,27 @@
+package ready_to_marry.authservice.social.dto.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 소셜 인증 서버(OAuth2 Provider)로부터 토큰 응답을 받을 때 사용하는 DTO
+ *
+ * 인가 코드(code)와 code_verifier를 이용해 액세스 토큰을 요청하면,
+ * 소셜 서버가 반환하는 access_token, refresh_token, expires_in 값을 매핑
+ */
+@Getter
+@NoArgsConstructor
+public class OAuth2Token {
+    // 액세스 토큰 (사용자 정보 조회 시 사용)
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    // 리프레시 토큰 (토큰 만료 시 재발급에 사용)
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    // 액세스 토큰 만료 시간 (초 단위)
+    @JsonProperty("expires_in")
+    private long expiresIn;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/SocialUserInfo.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/SocialUserInfo.java
@@ -1,0 +1,23 @@
+package ready_to_marry.authservice.social.dto.external;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 소셜 인증 서버로부터 사용자 정보를 조회할 때 사용하는 DTO
+ *
+ * 액세스 토큰을 이용해 사용자 정보를 요청하면,
+ * 응답으로 제공되는 사용자 고유 ID를 매핑
+ */
+@Getter
+@NoArgsConstructor
+public class SocialUserInfo {
+    // 소셜 사용자 고유 ID
+    // - Kakao/Naver: "id"
+    // - Google:      "sub"
+    @JsonProperty("id")
+    @JsonAlias("sub")
+    private String id;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/dto/response/SocialAuthResponse.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/dto/response/SocialAuthResponse.java
@@ -1,0 +1,34 @@
+package ready_to_marry.authservice.social.dto.response;
+
+import lombok.*;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+
+import java.util.UUID;
+
+/**
+ * 소셜 로그인/회원가입 후 클라이언트에 반환할 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SocialAuthResponse {
+    // 인증 흐름 상태
+    public enum Status {
+        // 프로필 미완료
+        INCOMPLETE,
+
+        // 인증 및 회원가입 완료 (프로필 완료)
+        SUCCESS
+    }
+
+    // AUTH 흐름 상태
+    private Status status;
+
+    // status == INCOMPLETE 일 때만 세팅 (프론트가 이 accountId 로 프로필 등록 호출)
+    private UUID accountId;
+
+    // status == SUCCESS 일 때만 세팅 (JWT 토큰 정보)
+    private JwtResponse tokens;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/repository/OAuthStateRepository.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/repository/OAuthStateRepository.java
@@ -1,0 +1,33 @@
+package ready_to_marry.authservice.social.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * OAuth2 state 와 PKCE verifier 저장소 추상화 인터페이스
+ */
+public interface OAuthStateRepository {
+    /**
+     * state → verifier 매핑을 TTL 과 함께 저장
+     *
+     * @param state     CSRF 방지를 위한 state 문자열
+     * @param verifier  PKCE 코드 검증을 위한 code_verifier 문자열
+     * @param ttl       키 만료까지의 기간(Duration)
+     */
+    void save(String state, String verifier, Duration ttl);
+
+    /**
+     * state 로 저장된 verifier 조회
+     *
+     * @param state                CSRF 방지를 위한 state 문자열
+     * @return Optional<String>    verifier (없으면 Optional.empty)
+     */
+    Optional<String> find(String state);
+
+    /**
+     * state 키 삭제
+     *
+     * @param state     CSRF 방지를 위한 state 문자열
+     */
+    void delete(String state);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/repository/RedisOAuthStateRepository.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/repository/RedisOAuthStateRepository.java
@@ -1,0 +1,35 @@
+package ready_to_marry.authservice.social.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisOAuthStateRepository implements OAuthStateRepository {
+    private static final String KEY_PREFIX = "oauth2_state:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void save(String state, String verifier, Duration ttl) {
+        String key = KEY_PREFIX + state;
+        redisTemplate.opsForValue().set(key, verifier, ttl);
+    }
+
+    @Override
+    public Optional<String> find(String state) {
+        String key = KEY_PREFIX + state;
+        String v = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(v);
+    }
+
+    @Override
+    public void delete(String state) {
+        String key = KEY_PREFIX + state;
+        redisTemplate.delete(key);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuth2Service.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuth2Service.java
@@ -1,0 +1,51 @@
+package ready_to_marry.authservice.social.service;
+
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.social.dto.SocialLoginResult;
+
+/**
+ * 소셜 로그인(OAuth2 PKCE + state 기반 인증) 전 과정을 백엔드에서 전담 처리하는 서비스 인터페이스
+ *
+ * 지원되는 provider(Kakao 등)에 따라 인증 URL 생성 및 callback 처리 로직을 추상화
+ */
+public interface OAuth2Service {
+    /**
+     * 소셜 로그인 인증 요청 URL을 생성
+     * 1) CSRF + PKCE 방지를 위한 state 및 code_verifier 생성
+     * 2) Redis에 (state→verifier) 저장
+     * 3) Provider 로 SocialOAuthClient 조회
+     * 4) Provider별 구현체에서 인가 요청 URL을 구성하여 반환
+     *
+     * @param provider                  소셜 로그인 제공자 (예: "kakao")
+     * @return String                   소셜 인증 서버로 이동하기 위한 인가 요청 URL
+     * @throws BusinessException        PROVIDER_NOT_SUPPORTED
+     * @throws InfrastructureException  PKCE_CHALLENGE_GENERATION_FAILURE
+     * @throws InfrastructureException  OAUTH_STATE_SAVE_FAILURE
+     */
+    String buildAuthUrl(String provider);
+
+    /**
+     * 소셜 인증 서버로부터 받은 인가 코드와 state를 처리하여 로그인 또는 2단계 가입 흐름을 수행
+     * 1) Redis에서 state로 PKCE verifier(code_verifier) 조회 → → CSRF/state 검증 겸 만료 검증
+     * 2) Provider 로 SocialOAuthClient 조회
+     * 3) 인가 코드 → 액세스 토큰 교환
+     * 4) 액세스 토큰 → 사용자 정보 조회
+     * 5) socialId 생성 (provider|id)
+     * 6) 2단계 가입 흐름 수행
+     *
+     * @param provider                  소셜 로그인 제공자 (예: "kakao")
+     * @param code                      소셜 인증 서버가 전달한 인가 코드
+     * @param state                     요청 시 전달된 CSRF 방지용 state 값
+     * @return SocialLoginResult        로그인 결과 (JWT 토큰 발급 or 프로필 입력 요청)
+     * @throws BusinessException        PROVIDER_NOT_SUPPORTED
+     * @throws BusinessException        INVALID_OAUTH2_STATE
+     * @throws InfrastructureException  OAUTH_STATE_RETRIEVE_REMOVE_FAILURE
+     * @throws InfrastructureException  OAUTH_TOKEN_EXCHANGE_FAILURE
+     * @throws InfrastructureException  OAUTH_USERINFO_FAILURE
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     * @throws InfrastructureException  REFRESH_TOKEN_SAVE_FAILURE
+     */
+    SocialLoginResult handleCallback(String provider, String code, String state);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuth2ServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuth2ServiceImpl.java
@@ -1,0 +1,106 @@
+package ready_to_marry.authservice.social.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.common.util.MaskingUtil;
+import ready_to_marry.authservice.social.client.SocialOAuthClient;
+import ready_to_marry.authservice.social.dto.SocialLoginResult;
+import ready_to_marry.authservice.social.dto.external.OAuth2Token;
+import ready_to_marry.authservice.social.dto.external.SocialUserInfo;
+import ready_to_marry.authservice.social.util.OAuth2Utils;
+import ready_to_marry.authservice.user.service.UserAuthService;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuth2ServiceImpl implements OAuth2Service {
+    private final Map<String, SocialOAuthClient> oauthClients;
+    private final UserAuthService userAuthService;
+    private final OAuthStateService oAuthStateService;
+
+    @Override
+    public String buildAuthUrl(String provider) {
+        // 1) CSRF + PKCE 방지를 위한 state 및 code_verifier 생성
+        String state    = OAuth2Utils.generateState();
+        String verifier = OAuth2Utils.generateCodeVerifier();
+        String challenge= OAuth2Utils.toCodeChallenge(verifier);
+
+        // 2) Redis에 (state→verifier) 저장
+        try {
+            oAuthStateService.saveVerifier(state, verifier);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=state, identifierValue={}", ErrorCode.OAUTH_STATE_SAVE_FAILURE.getMessage(), MaskingUtil.maskState(state), ex);
+            throw new InfrastructureException(ErrorCode.OAUTH_STATE_SAVE_FAILURE, ex);
+        }
+
+        // 3) Provider 로 SocialOAuthClient 조회
+        SocialOAuthClient client = oauthClients.get(provider);
+
+        if (client == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), provider);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        // 4) Provider별 구현체에서 인가 요청 URL을 구성하여 반환
+        return client.getAuthorizationUrl(state, challenge);
+    }
+
+    @Override
+    @Transactional
+    public SocialLoginResult handleCallback(String provider, String code, String state) {
+        // 1) Redis에서 state로 PKCE verifier(code_verifier) 조회 → → CSRF/state 검증 겸 만료 검증
+        String verifier;
+        try {
+            verifier = oAuthStateService.retrieveAndRemoveVerifier(state)
+                    .orElseThrow(() -> {
+                        log.error("{}: identifierType=state, identifierValue={}", ErrorCode.INVALID_OAUTH2_STATE.getMessage(), MaskingUtil.maskState(state));
+                        return new BusinessException(ErrorCode.INVALID_OAUTH2_STATE);
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=state, identifierValue={}", ErrorCode.OAUTH_STATE_RETRIEVE_REMOVE_FAILURE.getMessage(), MaskingUtil.maskState(state), ex);
+            throw new InfrastructureException(ErrorCode.OAUTH_STATE_RETRIEVE_REMOVE_FAILURE, ex);
+        }
+
+        // 2) Provider 로 SocialOAuthClient 조회
+        SocialOAuthClient client = oauthClients.get(provider);
+
+        if (client == null) {
+            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), provider);
+            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+        }
+
+        // 3) 인가 코드 → 액세스 토큰 교환
+        OAuth2Token token;
+        try {
+            token = client.getToken(code, verifier);
+        } catch (WebClientRequestException | WebClientResponseException ex) {
+            log.error("{}: identifierType=code, identifierValue={}", ErrorCode.OAUTH_TOKEN_EXCHANGE_FAILURE.getMessage(), MaskingUtil.maskCode(code), ex);
+            throw new InfrastructureException(ErrorCode.OAUTH_TOKEN_EXCHANGE_FAILURE, ex);
+        }
+
+        // 4) 액세스 토큰 → 사용자 정보 조회
+        SocialUserInfo userInfo;
+        try {
+            userInfo = client.getUserInfo(token.getAccessToken());
+        } catch (WebClientRequestException | WebClientResponseException ex) {
+            log.error("{}: identifierType=accessToken, identifierValue={}", ErrorCode.OAUTH_USERINFO_FAILURE.getMessage(), MaskingUtil.maskToken(token.getAccessToken()), ex);
+            throw new InfrastructureException(ErrorCode.OAUTH_USERINFO_FAILURE, ex);
+        }
+
+        // 5) socialId 생성 (provider|id)
+        String socialId = provider + "|" + userInfo.getId();
+
+        // 6) 2단계 가입 흐름 수행
+        return userAuthService.socialLogin(provider, socialId);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuthStateService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuthStateService.java
@@ -1,0 +1,24 @@
+package ready_to_marry.authservice.social.service;
+
+import java.util.Optional;
+
+/**
+ * CSRF 방지 및 PKCE 관리를 위한 서비스 인터페이스
+ */
+public interface OAuthStateService {
+    /**
+     * CSRF 방지를 위한 state 값과 PKCE 인증용 verifier(code_verifier)를 저장
+     *
+     * @param state     CSRF 방지를 위한 state 문자열
+     * @param verifier  PKCE 코드 검증을 위한 code_verifier 문자열
+     */
+    void saveVerifier(String state, String verifier);
+
+    /**
+     * 저장된 verifier(code_verifier)를 state 키로 조회하고, 조회 후 해당 키를 삭제
+     *
+     * @param state               CSRF 방지를 위한 state 문자열
+     * @return Optional<String>   조회된 code_verifier 문자열 (없으면 Optional.empty)
+     */
+    Optional<String> retrieveAndRemoveVerifier(String state);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuthStateServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/service/OAuthStateServiceImpl.java
@@ -1,0 +1,42 @@
+package ready_to_marry.authservice.social.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import ready_to_marry.authservice.social.config.OAuthProviderProperties;
+import ready_to_marry.authservice.social.repository.OAuthStateRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthStateServiceImpl implements OAuthStateService {
+    private final OAuthStateRepository oAuthStateRepository;
+    private final OAuthProviderProperties oAuthProviderProperties;
+
+    @Override
+    // 저장 중 DataAccessException 발생 시, 최대 3회까지 재시도(backoff 100ms)한 뒤 예외를 전파
+    @Retryable(
+            include = DataAccessException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public void saveVerifier(String state, String verifier) {
+        oAuthStateRepository.save(state, verifier, oAuthProviderProperties.getStateTtl());
+    }
+
+    @Override
+    // 조회 또는 삭제 중 DataAccessException 발생 시, 최대 3회까지 재시도(backoff 100ms)한 뒤 예외를 전파
+    @Retryable(
+            include = DataAccessException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public Optional<String> retrieveAndRemoveVerifier(String state) {
+        Optional<String> verifier = oAuthStateRepository.find(state);
+        verifier.ifPresent(v -> oAuthStateRepository.delete(state));
+        return verifier;
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/social/util/OAuth2Utils.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/util/OAuth2Utils.java
@@ -1,0 +1,54 @@
+package ready_to_marry.authservice.social.util;
+
+import lombok.extern.slf4j.Slf4j;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.common.util.MaskingUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.UUID;
+
+@Slf4j
+public class OAuth2Utils {
+    private static final SecureRandom random = new SecureRandom();
+    private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+    private OAuth2Utils() {
+        // 유틸 클래스이므로 인스턴스 생성 방지
+    }
+
+    /**
+     * PKCE code_verifier 생성 (RFC7636 권장: 43~128자, URL-safe Base64)
+     */
+    public static String generateCodeVerifier() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return encoder.encodeToString(bytes);
+    }
+
+    /**
+     * SHA-256 해시 후 URL-safe Base64 인코딩하여 code_challenge 생성
+     *
+     * @throws InfrastructureException PKCE_CHALLENGE_GENERATION_FAILURE
+     */
+    public static String toCodeChallenge(String verifier) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            return encoder.encodeToString(digest);
+        } catch (Exception ex) {
+            log.error("{}: identifierType=verifier, identifierValue={}", ErrorCode.PKCE_CHALLENGE_GENERATION_FAILURE.getMessage(), MaskingUtil.maskVerifier(verifier), ex);
+            throw new InfrastructureException(ErrorCode.PKCE_CHALLENGE_GENERATION_FAILURE, ex);
+        }
+    }
+
+    /**
+     * CSRF 방지를 위한 state 토큰 생성
+     */
+    public static String generateState() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/controller/UserAuthController.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/controller/UserAuthController.java
@@ -1,0 +1,43 @@
+package ready_to_marry.authservice.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.authservice.common.dto.response.ApiResponse;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.user.dto.request.UserProfileCompletionRequest;
+import ready_to_marry.authservice.user.service.UserAuthService;
+
+/**
+ * 유저 프로필 등록 완료 및 JWT 토큰 발급 컨트롤러
+ */
+@RestController
+@RequestMapping("/auth/users")
+@RequiredArgsConstructor
+public class UserAuthController {
+    private final UserAuthService userAuthService;
+
+    /**
+     * 프로필 등록 완료 후 JWT 토큰 발급
+     *
+     * @param request accountId 및 추가 프로필 정보
+     * @return 성공 시 code=0, data=발급된 JWT 토큰 정보
+     */
+    @PostMapping("/profile/complete")
+    public ResponseEntity<ApiResponse<JwtResponse>> completeProfile(@Valid @RequestBody UserProfileCompletionRequest request) {
+        // 프로필 등록 완료 후 JWT 토큰 발급
+        JwtResponse tokens = userAuthService.completeUserProfile(request);
+
+        ApiResponse<JwtResponse> body = ApiResponse.<JwtResponse>builder()
+                .code(0)
+                .message("User profile completed + User login successful")
+                .data(tokens)
+                .build();
+
+        return ResponseEntity.ok(body);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
@@ -1,0 +1,35 @@
+package ready_to_marry.authservice.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * 유저 프로필 등록 완료 요청 DTO
+ *
+ * 소셜 로그인 후 추가로 받아야 할 사용자 프로필 정보
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileCompletionRequest {
+    // 유저 계정 고유 ID
+    @NotNull
+    private UUID accountId;
+
+    // 유저 실명(또는 표시명)
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    // 유저 연락처: 맨 앞에 + 가 0~1회 올 수 있고 그 뒤에는 숫자나 하이픈만 조합
+    @NotBlank
+    @Pattern(regexp = "^\\+?[0-9\\-]{1,20}$")
+    private String phone;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
@@ -1,0 +1,22 @@
+package ready_to_marry.authservice.user.dto.request;
+
+import lombok.*;
+
+/**
+ * 유저 프로필 저장 INTERNAL API 요청시 보낼 DTO
+ *
+ * 유저 소셜 로그인 후 유저 프로필 등록 완료 요청 시 클라이언트로부터 전달받을 정보 중 유저 프로필 저장에 필요한 정보
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileRequest {
+
+    // 유저 실명(또는 표시명)
+    private String name;
+
+    // 유저 연락처
+    private String phone;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
@@ -1,0 +1,59 @@
+package ready_to_marry.authservice.user.service;
+
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.social.dto.SocialLoginResult;
+import ready_to_marry.authservice.user.dto.request.UserProfileCompletionRequest;
+
+/**
+ * 유저 소셜 로그인 및 프로필 완성 후 JWT 발급을 담당하는 서비스 인터페이스
+ *
+ * OAuth2 기반 소셜 로그인 후, 해당 유저의 계정 존재 여부 및 프로필 완료 상태를 판단
+ * 신규 계정 생성 또는 기존 계정 조회 후, 프로필이 미완료된 경우 accountId를 반환 (SocialLoginResult.incomplete)
+ * 프로필이 완료된 경우, JWT 액세스/리프레시 토큰을 발급 (SocialLoginResult.active)
+ *
+ * 프로필 입력 요청을 받아 프로필을 등록하고 계정 상태를 ACTIVE로 변경 후 JWT 토큰을 발급
+ *
+ * 이 서비스는 OAuth2 인증 흐름의 최종 단계에서 호출되며, 소셜 인증 서버와 직접 통신하지는 않음
+ */
+public interface UserAuthService {
+    /**
+     * 소셜 로그인 처리
+     * 1) 소셜 ID로 계정 조회 또는 신규 생성
+     * 2) ACTIVE 상태이면 JWT 토큰 발급
+     * 2-1) JWT 토큰 발급 (Access Token 생성)
+     * 2-2) JWT 토큰 발급 (Refresh Token 생성)
+     * 2-3) Refresh Token Redis에 저장
+     * 3) WAITING_PROFILE_COMPLETION 상태이면 프로필 등록 유도
+     *
+     * @param socialId                      "provider|소셜유저ID" 형태의 통합 소셜 식별자
+     * @return SocialLoginResult            프로필 미완료이면 accountId 포함, ACTIVE 회원이면 access/refresh 토큰 포함
+     * @throws BusinessException            PROVIDER_NOT_SUPPORTED
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException      DB_SAVE_FAILURE
+     * @throws InfrastructureException      REFRESH_TOKEN_SAVE_FAILURE
+     */
+    SocialLoginResult socialLogin(String provider, String socialId);
+
+    /**
+     * 프로필 등록 완료 처리 후 JWT 토큰 발급
+     * 1) accountId 유효성 및 상태 확인
+     * 2)-1 USER SERVICE에 요청할 DTO 생성 (INTERNAL API)
+     * 2)-2 USER SERVICE에 요청 (INTERNAL API) → user_profile(userDB)에 저장
+     * 3) auth_account에 userId, status 업데이트
+     * 4) JWT 토큰 발급 (Access Token 생성)
+     * 5) JWT 토큰 발급 (Refresh Token 생성)
+     * 6) Refresh Token Redis에 저장
+     * 7) 최종 응답 DTO 반환
+     *
+     * @param request                       프로필 완성 요청 DTO (accountId, 추가 정보)
+     * @return JwtResponse                  발급된 access/refresh 토큰 + expiresIn (만료 시간)
+     * @throws BusinessException            ACCOUNT_NOT_FOUND
+     * @throws BusinessException            PROFILE_ALREADY_COMPLETED
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException      DB_SAVE_FAILURE
+     * @throws InfrastructureException      REFRESH_TOKEN_SAVE_FAILURE
+     */
+    JwtResponse completeUserProfile(UserProfileCompletionRequest request);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
@@ -1,0 +1,173 @@
+package ready_to_marry.authservice.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.authservice.account.entity.AuthAccount;
+import ready_to_marry.authservice.account.service.AccountService;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.common.enums.AccountStatus;
+import ready_to_marry.authservice.common.enums.AuthMethod;
+import ready_to_marry.authservice.common.enums.Role;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.common.jwt.JwtClaims;
+import ready_to_marry.authservice.common.jwt.JwtProperties;
+import ready_to_marry.authservice.common.jwt.JwtTokenProvider;
+import ready_to_marry.authservice.common.util.MaskingUtil;
+import ready_to_marry.authservice.social.dto.SocialLoginResult;
+import ready_to_marry.authservice.token.service.RefreshTokenService;
+import ready_to_marry.authservice.user.dto.request.UserProfileCompletionRequest;
+import ready_to_marry.authservice.user.dto.request.UserProfileRequest;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserAuthServiceImpl implements UserAuthService {
+    private final AccountService accountService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    @Transactional
+    public SocialLoginResult socialLogin(String provider, String socialId) {
+        // 1) 소셜 ID로 계정 조회 또는 신규 생성
+        AuthAccount account;
+        try {
+            account = accountService.findByLoginId(socialId)
+                    .orElseGet(() -> {
+                        try {
+                            AuthMethod method = AuthMethod.valueOf(provider.toUpperCase());
+                            AuthAccount newAccount = AuthAccount.builder()
+                                    .authMethod(method)
+                                    .loginId(socialId)
+                                    .role(Role.USER)
+                                    .status(AccountStatus.WAITING_PROFILE_COMPLETION)
+                                    .build();
+                            return accountService.save(newAccount);
+                        } catch (IllegalArgumentException ex) {
+                            log.error("{}: identifierType=provider, identifierValue={}", ErrorCode.PROVIDER_NOT_SUPPORTED.getMessage(), provider);
+                            throw new BusinessException(ErrorCode.PROVIDER_NOT_SUPPORTED);
+                        } catch (DataAccessException ex) {
+                            log.error("{}: identifierType=loginId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtil.maskSocialLoginId(socialId), ex);
+                            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+                        }
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=loginId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtil.maskSocialLoginId(socialId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 2) ACTIVE 상태이면 JWT 토큰 발급
+        if (account.getStatus() == AccountStatus.ACTIVE) {
+            // 2-1) JWT 토큰 발급 (Access Token 생성)
+            String accessToken = jwtTokenProvider.generateAccessToken(
+                    account.getAccountId().toString(),
+                    // role, userId 설정
+                    JwtClaims.builder()
+                            .role(account.getRole().name())
+                            .userId(account.getUserId())
+                            .build()
+            );
+
+            // 2-2) JWT 토큰 발급 (Refresh Token 생성)
+            String refreshToken = jwtTokenProvider.generateRefreshToken(
+                    account.getAccountId().toString()
+            );
+
+
+            // 2-3) Refresh Token Redis에 저장
+            try {
+                refreshTokenService.save(account.getAccountId(), refreshToken);
+            }  catch (DataAccessException ex) {
+                log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_SAVE_FAILURE.getMessage(), account.getAccountId(), ex);
+                throw new InfrastructureException(ErrorCode.REFRESH_TOKEN_SAVE_FAILURE, ex);
+            }
+
+            return SocialLoginResult.active(accessToken, refreshToken, jwtProperties.getAccessExpiry());
+        }
+
+        // 3) WAITING_PROFILE_COMPLETION 상태이면 프로필 등록 유도
+        return SocialLoginResult.incomplete(account.getAccountId());
+    }
+
+    @Override
+    @Transactional
+    public JwtResponse completeUserProfile(UserProfileCompletionRequest request) {
+        // 1) accountId 유효성 및 상태 확인
+        AuthAccount account;
+        try {
+            account = accountService.findById(request.getAccountId())
+                    .orElseThrow(() -> {
+                        log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.ACCOUNT_NOT_FOUND.getMessage(), request.getAccountId());
+                        return new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND);
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), request.getAccountId(), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        if (account.getStatus() != AccountStatus.WAITING_PROFILE_COMPLETION) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.PROFILE_ALREADY_COMPLETED.getMessage(), request.getAccountId());
+            throw new BusinessException(ErrorCode.PROFILE_ALREADY_COMPLETED);
+        }
+
+        // 2)-1 USER SERVICE에 요청할 DTO 생성 (INTERNAL API)
+        UserProfileRequest internalRequest = UserProfileRequest.builder()
+                .name(request.getName())
+                .phone(request.getPhone())
+                .build();
+
+        // 2)-2 USER SERVICE에 요청 (INTERNAL API) → user_profile(userDB)에 저장
+        // TODO: INTERNAL API 호출 로직 추가
+        // TODO: INTERNAL API 호출 에러 시 처리 로직 추가
+        // FIXME: INTERNAL API 호출 결과에서 가져오는 userId로 변경 (임시 코드)
+        Random rnd = new Random();
+        Long userId = rnd.nextLong();
+
+        // 3) auth_account에 userId, status 업데이트
+        try {
+            accountService.updateUserIdAndStatus(request.getAccountId(), userId, AccountStatus.ACTIVE);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), request.getAccountId(), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+
+        // 4) JWT 토큰 발급 (Access Token 생성)
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                account.getAccountId().toString(),
+                // role, userId 설정
+                JwtClaims.builder()
+                        .role(account.getRole().name())
+                        .userId(account.getUserId())
+                        .build()
+        );
+
+        // 5) JWT 토큰 발급 (Refresh Token 생성)
+        String refreshToken = jwtTokenProvider.generateRefreshToken(
+                account.getAccountId().toString()
+        );
+
+
+        // 6) Refresh Token Redis에 저장
+        try {
+            refreshTokenService.save(account.getAccountId(), refreshToken);
+        }  catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_SAVE_FAILURE.getMessage(), account.getAccountId(), ex);
+            throw new InfrastructureException(ErrorCode.REFRESH_TOKEN_SAVE_FAILURE, ex);
+        }
+
+        // 7) 최종 응답 DTO 반환
+        return JwtResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(jwtProperties.getAccessExpiry())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- OAuth2 PKCE + state 기반 소셜 로그인부터 유저 프로필 완성, JWT 발급까지의 전반적인 인증·가입 흐름을 구현하고 관련 설정, 유틸, 예외 코드, 컨트롤러를 추가했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- 설정 및 빈 등록
   - WebClientConfig에 WebClient 빈 등록
   - OAuthProviderProperties 로 auth.oauth.* 프로퍼티 바인딩 (provider 설정, state TTL)
   
- PKCE & state 유틸
   - OAuth2Utils 에 generateCodeVerifier, toCodeChallenge, generateState 메서드 구현

- 에러 코드·마스킹 확장 & WebFlux 의존성
   - ErrorCode 에 OAuth2·유저 인증 관련 비즈니스·인프라 오류 추가
   - MaskingUtil 에 maskVerifier, maskState, maskCode, maskSocialLoginId 메서드 추가
   - build.gradle 에 spring-boot-starter-webflux 의존성 등록

- OAuth2 state·PKCE verifier 저장소 및 서비스
   - OAuthStateRepository 인터페이스 + RedisOAuthStateRepository 구현
   - OAuthStateService + OAuthStateServiceImpl 에 Redis 저장·조회·삭제 및 @Retryable 적용

- 소셜 OAuth 클라이언트
   - SocialOAuthClient 인터페이스 정의
   - Naver, Kakao, Google 구현체 추가 (WebClient + @Retryable)

- 외부 DTO
   - OAuth2Token, SocialUserInfo DTO로 토큰/사용자 정보 매핑

- 소셜 로그인 흐름 & 프로필 완성 DTO
   - SocialLoginResult (incomplete/active 팩토리 메서드)
   - UserProfileCompletionRequest, UserProfileRequest DTO 추가

- 서비스 레이어
   - OAuth2Service + OAuth2ServiceImpl:
      - buildAuthUrl (state/verifier 생성 → Redis 저장 → client URL 생성)
      - handleCallback() (state 검증 → token 교환 → user info 조회 → UserAuthService 위임)
   - UserAuthService + UserAuthServiceImpl:
      - socialLogin (기존 계정 조회 or 신규 생성 → 상태 분기)
      - completeUserProfile (프로필 저장 → auth_account 업데이트 → JWT 발급)

- 컨트롤러 & 응답 DTO
   - OAuth2Controller: /auth/oauth2/authorize/{provider}, /auth/oauth2/callback/{provider} 엔드포인트 구현
   - SocialAuthResponse: 상태(INCOMPLETE/SUCCESS) 및 accountId/tokens 반환
   - UserAuthController: /auth/users/profile/complete 엔드포인트 구현

- AccountService 확장 & SecurityConfig 업데이트
   - AccountService 에 updateUserIdAndStatus 메서드 추가, EntityNotFoundException 메시지 개선
   - SecurityConfig 에 /auth/oauth2/authorize/\*\*, /auth/oauth2/callback/\*\*, /auth/users/profile/complete 경로 허용

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- User 프로필 완성 시 USER SERVICE에 요청하여 user_profile(userDB)에 유저 프로필 정보를 저장하는 INTERNAL API 호출 로직 추가 필요
- 유저 프로필 정보를 저장하는 INTERNAL API 호출 결과에서 가져오는 userId로 변경 필요 (현재: 임시 코드)
- INTERNAL API 호출 에러 시 처리 로직 추가 필요
