### PR TITLE
Refactor/security filter: 인증·인가 필터 및 필터 단 예외 처리 리팩터링

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                         AbstractPreAuthenticatedProcessingFilter.class
                 )
 
-                // 2) access/refresh 토큰 파싱(accountId) & 컨텍스트 세팅 필터
+                // 2) 컨텍스트 세팅 필터
                 .addFilterAfter(
                         preAuthHeaderFilter(),
                         JwtRefreshTokenFilter.class
@@ -80,7 +80,7 @@ public class SecurityConfig {
 
     /**
      * refresh 토큰 유효성(서명+만료)만 검사하는
-     * refresh 흐름에서만 동작하는 필터
+     * 리프레시 엔드포인트 전용 필터
      */
     @Bean
     public JwtRefreshTokenFilter jwtRefreshTokenFilter() {
@@ -88,13 +88,11 @@ public class SecurityConfig {
     }
 
     /**
-     * access 또는 refresh 토큰을 직접 파싱(accountId)하고
-     * Gateway가 덮어쓴 X-헤더를 꺼내
-     * SecurityContext에 세팅하는 필터
+     * Gateway가 삽입한 X-헤더만 신뢰해서 SecurityContext에 인증정보를 세팅하는 필터
      */
     @Bean
     public PreAuthHeaderFilter preAuthHeaderFilter() {
-        return new PreAuthHeaderFilter(jwtTokenProvider);
+        return new PreAuthHeaderFilter();
     }
 
     /**

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.filter.OncePerRequestFilter;
-import ready_to_marry.authservice.common.jwt.JwtTokenProvider;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -19,41 +18,37 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * access/refresh 흐름 모두 처리하여 SecurityContext에 인증정보를 세팅
+ * Gateway가 삽입한 X-헤더만 신뢰해서 SecurityContext에 인증정보를 세팅
  *
- * Gateway가 삽입한 X-Role, X-User-Id/X-Partner-Id/X-Admin-Role 헤더와
- * 토큰에 담긴 accountId로 SecurityContext에 인증정보를 세팅
+ * Access Token 흐름: JWT 파싱 없이 Gateway가 삽입한 X-Account-Id, X-Role, X-User-Id/X-Partner-Id/X-Admin-Id/X-Admin-Role 헤더만 사용
+ * Refresh Token 흐름: JwtRefreshTokenFilter가 먼저 처리하므로 스킵
  */
 @Slf4j
 @RequiredArgsConstructor
 public class PreAuthHeaderFilter extends OncePerRequestFilter {
-    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 리프레시 엔드포인트는 JwtRefreshTokenFilter에서만 처리
+        // FIXME: refresh Token 흐름인 요청 주소 변경 확인
+        return "/auth/token/refresh".equals(request.getRequestURI());
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
+        String accountId  = request.getHeader("X-Account-Id");
+        String userId    = request.getHeader("X-User-Id");
+        String partnerId = request.getHeader("X-Partner-Id");
+        String adminId   = request.getHeader("X-Admin-Id");
+        String role      = request.getHeader("X-Role");
+        String adminRole = request.getHeader("X-Admin-Role");
 
-        // access Token 흐름: Gateway가 검증·헤더 셋팅
-        // refresh Token 흐름: JwtRefreshTokenFilter에서 이미 검증
-        String accountId  = null;
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            accountId = jwtTokenProvider.getSubject(authHeader.substring(7));
-        }
-
-        if (accountId != null) {
-            String role      = request.getHeader("X-Role");
-            String userId    = request.getHeader("X-User-Id");
-            String partnerId = request.getHeader("X-Partner-Id");
-            String adminRole = request.getHeader("X-Admin-Role");
-
+        if (accountId != null && role != null) {
             // 권한 리스트 생성
             List<SimpleGrantedAuthority> authorities = new ArrayList<>();
-            if (role != null) {
-                // 예: role="ADMIN" → "ROLE_ADMIN"
-                authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
-            }
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
             if ("ADMIN".equals(role) && adminRole != null) {
                 // 예: adminRole="SUPER_ADMIN" → "ROLE_SUPER_ADMIN"
                 authorities.add(new SimpleGrantedAuthority("ROLE_" + adminRole));
@@ -61,6 +56,7 @@ public class PreAuthHeaderFilter extends OncePerRequestFilter {
 
             PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(accountId, null, authorities);
 
+            // 내부 식별자 정보는 details로 설정
             Map<String,String> details = new HashMap<>();
             if (userId != null) {
                 details.put("userId", userId);
@@ -68,10 +64,13 @@ public class PreAuthHeaderFilter extends OncePerRequestFilter {
             if (partnerId != null) {
                 details.put("partnerId", partnerId);
             }
-
+            if (adminId != null) {
+                details.put("adminId", adminId);
+            }
             auth.setDetails(details);
+
             SecurityContextHolder.getContext().setAuthentication(auth);
-            log.debug("PreAuthHeaderFilter set authentication: accountId={}, role={}", accountId, role);
+            log.debug("PreAuthHeaderFilter set authentication: accountId={} role={}", accountId, role);
         }
 
         chain.doFilter(request, response);

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/security/RestAccessDeniedHandler.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/security/RestAccessDeniedHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * 권한이 부족할 때(403) JSON 응답을 내려주는 Handler
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
@@ -25,6 +27,8 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("403 Unauthorized on [{} {}]: reason={}", request.getMethod(), request.getRequestURI(), accessDeniedException.getMessage());
+
         ApiResponse<Void> body = ApiResponse.<Void>builder()
                 .code(403)
                 .message("Forbidden")

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/security/RestAuthenticationEntryPoint.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/security/RestAuthenticationEntryPoint.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * 인증이 필요할 때(401) JSON 응답을 내려주는 EntryPoint
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -25,6 +27,8 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
+        log.error("401 Unauthorized on [{} {}]: reason={}", request.getMethod(), request.getRequestURI(), authException.getMessage());
+
         ApiResponse<Void> body = ApiResponse.<Void>builder()
                 .code(401)
                 .message("Unauthorized")


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 변경된 인증/인가 전략에 따라 Security 필터와 필터 단 예외 처리의 책임과 구현을 수정했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- SecurityConfig
  - PreAuthHeaderFilter 빈 생성자에서 JwtTokenProvider 의존 제거
  - 주석 및 필터 설명 수정
- JwtRefreshTokenFilter
  - response.sendError 호출 대신 Spring Security 예외 (InsufficientAuthenticationException/BadCredentialsException)
  - 주석 수정
- PreAuthHeaderFilter
  - JWT 토큰 파싱 로직 제거, Gateway X-헤더(X-Account-Id, X-Role 등)만 신뢰
  - /auth/token/refresh 경로를 필터 실행 대상에서 제외하는 shouldNotFilter 구현
  - 변경된 설계에 따라 X-Account-Id, X-Admin-Id 헤더 처리 로직 추가
  - 주석 수정
- RestAccessDeniedHandler
  - 403 응답 시 log.error로 요청 메서드, URI, 사유 로깅 추가
- RestAuthenticationEntryPoint
  - 401 응답 시 log.error로 요청 메서드, URI, 사유 로깅 추가

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- refresh 흐름 엔드포인트 변경 시 JwtRefreshTokenFilter/PreAuthHeaderFilter.shouldNotFilter() 업데이트 필요