### PR TITLE
Feat/jwt token refresh: 리프레시 토큰 기반 토큰 재발급 기능 구현

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/common/exception/ErrorCode.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/exception/ErrorCode.java
@@ -17,22 +17,27 @@ public enum ErrorCode {
     INVALID_OAUTH2_STATE(1308, "Invalid OAuth2 state"),
     ACCOUNT_NOT_FOUND(1309, "Account not found"),
     PROFILE_ALREADY_COMPLETED(1310, "User profile is already completed"),
+    REFRESH_TOKEN_INVALID(1311, "Invalid refresh token subject"),
+    REFRESH_TOKEN_NOT_FOUND(1312, "Refresh token not found"),
+    REFRESH_TOKEN_MISMATCH(1313, "Refresh token does not match"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2301, "System error occurred while saving data to the database"),
     DB_DELETE_FAILURE(2302, "System error occurred while deleting data from the database"),
     DB_RETRIEVE_FAILURE(2303, "System error occurred while retrieving data from the database"),
     REFRESH_TOKEN_SAVE_FAILURE(2304, "System error occurred while saving refresh token to redis"),
-    VERIFICATION_TOKEN_SAVE_FAILURE(2305, "System error occurred while saving verification token to redis"),
-    VERIFICATION_TOKEN_DELETE_FAILURE(2306, "System error occurred while deleting verification token from redis"),
-    VERIFICATION_TOKEN_RETRIEVE_FAILURE(2307, "System error occurred while retrieving verification token from redis"),
-    EMAIL_SEND_FAILURE(2308, "System error occurred while sending verification email"),
-    JSON_SERIALIZATION_FAILURE(2309, "System error occurred while serializing object to JSON"),
-    PKCE_CHALLENGE_GENERATION_FAILURE(2310, "System error occurred while generating PKCE code_challenge"),
-    OAUTH_STATE_SAVE_FAILURE(2311, "System error occurred while saving OAuth state"),
-    OAUTH_STATE_RETRIEVE_REMOVE_FAILURE(2312, "System error occurred while retrieving or removing OAuth state"),
-    OAUTH_TOKEN_EXCHANGE_FAILURE(2313, "System error occurred while exchanging OAuth token"),
-    OAUTH_USERINFO_FAILURE(2314, "System error occurred while fetching user info from OAuth provider");
+    REFRESH_TOKEN_DELETE_FAILURE(2305, "System error occurred while deleting refresh token to redis"),
+    REFRESH_TOKEN_RETRIEVE_FAILURE(2306, "System error occurred while retrieving refresh token to redis"),
+    VERIFICATION_TOKEN_SAVE_FAILURE(2307, "System error occurred while saving verification token to redis"),
+    VERIFICATION_TOKEN_DELETE_FAILURE(2308, "System error occurred while deleting verification token from redis"),
+    VERIFICATION_TOKEN_RETRIEVE_FAILURE(2309, "System error occurred while retrieving verification token from redis"),
+    EMAIL_SEND_FAILURE(2310, "System error occurred while sending verification email"),
+    JSON_SERIALIZATION_FAILURE(2311, "System error occurred while serializing object to JSON"),
+    PKCE_CHALLENGE_GENERATION_FAILURE(2312, "System error occurred while generating PKCE code_challenge"),
+    OAUTH_STATE_SAVE_FAILURE(2313, "System error occurred while saving OAuth state"),
+    OAUTH_STATE_RETRIEVE_REMOVE_FAILURE(2314, "System error occurred while retrieving or removing OAuth state"),
+    OAUTH_TOKEN_EXCHANGE_FAILURE(2315, "System error occurred while exchanging OAuth token"),
+    OAUTH_USERINFO_FAILURE(2316, "System error occurred while fetching user info from OAuth provider");
 
     private final int code;
     private final String message;

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/controller/RefreshTokenController.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/controller/RefreshTokenController.java
@@ -1,0 +1,44 @@
+package ready_to_marry.authservice.token.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.authservice.common.dto.response.ApiResponse;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.token.service.TokenService;
+
+/**
+ * 리프레시 토큰을 사용한 JWT 토큰 재발급을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/auth/token")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+    private final TokenService tokenService;
+
+    /**
+     * 유저, 파트너, 어드민의 리프레시
+     *
+     * @param authorizationHeader Authorization 헤더 (Bearer <refreshToken>)
+     * @return 성공 시 code=0, data=새로 발급된 JWT 토큰 정보
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<JwtResponse>> refresh(@RequestHeader("Authorization") String authorizationHeader) {
+        // "Bearer " 접두어 제거하여 순수 토큰 문자열만 추출
+        String refreshToken = authorizationHeader.replaceFirst("^Bearer ", "");
+
+        // 리프레시 토큰 검증 후 JWT 토큰 재생성 및 Redis에 저장
+        JwtResponse tokens = tokenService.refresh(refreshToken);
+
+        ApiResponse<JwtResponse> response = ApiResponse.<JwtResponse>builder()
+                .code(0)
+                .message("Refresh successful")
+                .data(tokens)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/repository/RedisRefreshTokenRepository.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/repository/RedisRefreshTokenRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -18,5 +19,17 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
     public void save(UUID accountId, String token, Duration ttl) {
         String key = KEY_PREFIX + accountId;
         redisTemplate.opsForValue().set(key, token, ttl);
+    }
+
+    @Override
+    public Optional<String> find(UUID accountId) {
+        String key = KEY_PREFIX + accountId;
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+    }
+
+    @Override
+    public void delete(UUID accountId) {
+        String key = KEY_PREFIX + accountId;
+        redisTemplate.delete(key);
     }
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/repository/RefreshTokenRepository.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package ready_to_marry.authservice.token.repository;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -15,4 +16,19 @@ public interface RefreshTokenRepository {
      * @param ttl       토큰 만료까지의 기간(Duration)
      */
     void save(UUID accountId, String token, Duration ttl);
+
+    /**
+     * 지정된 계정 ID에 저장된 리프레시 토큰을 조회
+     *
+     * @param accountId 조회할 refresh 토큰 계정의 고유 ID
+     * @return 저장된 refresh 토큰 문자열 (없으면 Optional.empty())
+     */
+    Optional<String> find(UUID accountId);
+
+    /**
+     * 지정된 계정 ID에 대한 리프레시 토큰을 삭제
+     *
+     * @param accountId 삭제할 refresh 토큰 계정의 고유 ID
+     */
+    void delete(UUID accountId);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/service/RefreshTokenService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/service/RefreshTokenService.java
@@ -1,9 +1,10 @@
 package ready_to_marry.authservice.token.service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Refresh Token 저장·검증·삭제 기능 제공
+ * Refresh Token 저장·조회·삭제 기능 제공
  */
 public interface RefreshTokenService {
     /**
@@ -13,4 +14,19 @@ public interface RefreshTokenService {
      * @param token     발급된 refresh 토큰 문자열
      */
     void save(UUID accountId, String token);
+
+    /**
+     * 계정ID에 해당하는 리프레시 토큰을 조회
+     *
+     * @param accountId 조회할 refresh 토큰 계정의 고유 ID
+     * @return 저장된 refresh 토큰 문자열 (없으면 Optional.empty())
+     */
+    Optional<String> findRefreshToken(UUID accountId);
+
+    /**
+     * 계정ID에 해당하는 리프레시 토큰을 삭제
+     *
+     * @param accountId 삭제할 refresh 토큰 계정의 고유 ID
+     */
+    void delete(UUID accountId);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/service/TokenService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/service/TokenService.java
@@ -1,0 +1,33 @@
+package ready_to_marry.authservice.token.service;
+
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+
+/**
+ * 리프레시 기능 관련 비즈니스 로직을 제공하는 서비스 인터페이스
+ */
+public interface TokenService {
+    /**
+     * 클라이언트가 가진 refresh token 으로 새로운 토큰 쌍을 발급
+     * 1) 리프레시 토큰 서명·만료 검증은 JwtRefreshTokenFilter가 이미 담당
+     * 2) subject(accountId) 추출 및 형식 검증
+     * 3) 저장소 검증: 저장된 토큰 조회 및 비교
+     * 4) 계정 정보 조회
+     * 5) 새 Access Token 생성
+     * 6) 새 Refresh Token 생성
+     * 7) 새 Refresh Token Redis에 저장 (기존 덮어쓰기)
+     * 8) 응답 DTO
+     *
+     * @param token 리프레시 토큰
+     * @return 새로 발급된 JWT 토큰 정보
+     * @throws BusinessException        REFRESH_TOKEN_INVALID
+     * @throws BusinessException        REFRESH_TOKEN_NOT_FOUND
+     * @throws BusinessException        REFRESH_TOKEN_MISMATCH
+     * @throws BusinessException        ACCOUNT_NOT_FOUND
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  REFRESH_TOKEN_RETRIEVE_FAILURE
+     * @throws InfrastructureException  REFRESH_TOKEN_SAVE_FAILURE
+     */
+    JwtResponse refresh(String token);
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/token/service/TokenServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/token/service/TokenServiceImpl.java
@@ -1,0 +1,123 @@
+package ready_to_marry.authservice.token.service;
+
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.authservice.account.entity.AuthAccount;
+import ready_to_marry.authservice.account.service.AccountService;
+import ready_to_marry.authservice.common.dto.response.JwtResponse;
+import ready_to_marry.authservice.common.exception.BusinessException;
+import ready_to_marry.authservice.common.exception.ErrorCode;
+import ready_to_marry.authservice.common.exception.InfrastructureException;
+import ready_to_marry.authservice.common.jwt.JwtClaims;
+import ready_to_marry.authservice.common.jwt.JwtProperties;
+import ready_to_marry.authservice.common.jwt.JwtTokenProvider;
+import ready_to_marry.authservice.common.util.MaskingUtil;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProperties jwtProperties;
+    private final AccountService accountService;
+
+    @Override
+    @Transactional
+    public JwtResponse refresh(String token) {
+        // 1) 리프레시 토큰 서명·만료 검증은 JwtRefreshTokenFilter가 이미 담당
+
+        // 2) subject(accountId) 추출 및 형식 검증
+        UUID accountId;
+        try {
+            // subject 추출 + UUID 변환
+            accountId = UUID.fromString(jwtTokenProvider.getSubject(token));
+        } catch (JwtException | IllegalArgumentException ex) {
+            // 서명·만료 검증은 이미 필터에서, 여기서는 subject가 없거나 UUID 형식이 아닐 때
+            log.error("{}: identifierType=token, identifierValue={}", ErrorCode.REFRESH_TOKEN_INVALID.getMessage(), MaskingUtil.maskToken(token));
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        // 3) 저장소 검증: 저장된 토큰 조회 및 비교
+        String savedRefreshToken;
+        try {
+            savedRefreshToken = refreshTokenService.findRefreshToken(accountId)
+                    .orElseThrow(() -> {
+                        log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage(), accountId);
+                        return new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_RETRIEVE_FAILURE.getMessage(), accountId, ex);
+            throw new InfrastructureException(ErrorCode.REFRESH_TOKEN_RETRIEVE_FAILURE, ex);
+        }
+
+        if (!savedRefreshToken.equals(token)) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_MISMATCH.getMessage(), accountId);
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 4) 계정 정보 조회
+        AuthAccount account;
+        try {
+            account = accountService.findById(accountId)
+                    .orElseThrow(() -> {
+                        log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.ACCOUNT_NOT_FOUND.getMessage(), accountId);
+                        return new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND);
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), accountId, ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 5) 새 Access Token 생성
+        JwtClaims.JwtClaimsBuilder claimsBuilder = JwtClaims.builder()
+                .role(account.getRole().name());
+
+        switch (account.getRole()) {
+            case USER:
+                claimsBuilder.userId(account.getUserId());
+                break;
+            case PARTNER:
+                claimsBuilder.partnerId(account.getPartnerId());
+                break;
+            case ADMIN:
+                claimsBuilder.adminRole(account.getAdminRole().name());
+                break;
+            default:
+                break;
+        }
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(
+                accountId.toString(),
+                claimsBuilder.build()
+        );
+
+        // 6) 새 Refresh Token 생성
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(
+                accountId.toString()
+        );
+
+        // 7) 새 Refresh Token Redis에 저장 (기존 덮어쓰기)
+        try {
+            refreshTokenService.save(accountId, newRefreshToken);
+        }  catch (DataAccessException ex) {
+            log.error("{}: identifierType=accountId, identifierValue={}", ErrorCode.REFRESH_TOKEN_SAVE_FAILURE.getMessage(), accountId, ex);
+            throw new InfrastructureException(ErrorCode.REFRESH_TOKEN_SAVE_FAILURE, ex);
+        }
+
+        // 8) 응답 DTO
+        long expiresIn = jwtProperties.getAccessExpiry(); // 초 단위 만료 시간
+
+        return JwtResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .expiresIn(expiresIn)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 클라이언트가 보유한 리프레시 토큰을 사용해 새로운 Access/Refresh 토큰을 재발급하는 기능을 추가했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- ErrorCode
   - 리프레시 흐름 관련 비즈니스 오류 및 인프라 오류 코드를 추가·조정
   
- RefreshTokenRepository & RedisRefreshTokenRepository
   - find(UUID accountId)와 delete(UUID accountId) 메서드를 선언 및 구현하여 Redis 기반 CRUD 지원을 확장

- RefreshTokenService & RefreshTokenServiceImpl
   - findRefreshToken(UUID accountId) 및 delete(UUID accountId) 메서드를 선언 및 구현 
   - @Retryable 재시도 로직을 적용

- TokenService & TokenServiceImpl
   - refresh(String token) 메서드를 선언 및 구현 
   - 토큰 subject 검증 → Redis에 저장된 리프레시 토큰 조회·검증 → 계정 조회 → 역할별 클레임 설정 후 새 Access/Refresh 토큰 생성 및 Redis에 저장

- RefreshTokenController
   - /auth/token/refresh 엔드포인트를 추가해 Authorization: Bearer <refreshToken> 헤더를 받아 토큰 재발급을 처리

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
