### PR TITLE
Refactor/security filter order and exclusions: 필터 순서 재구성 및 특정 엔드포인트 인증 제외 처리

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
@@ -26,12 +26,24 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 public class PreAuthHeaderFilter extends OncePerRequestFilter {
+    // 스킵할 URL 패턴
+    private static final List<String> EXCLUDE_URLS = List.of(
+            // FIXME: permitAll인 요청 주소 변경 확인
+            "/auth/oauth2/authorize/**",
+            "/auth/oauth2/callback/**",
+            "/auth/users/profile/complete",
+            "/auth/partners/login",
+            "/auth/partners/signup",
+            "/auth/partners/verify",
+            "/auth/partners/verify/result",
+            "/auth/admins/login",
+            "/auth/token/refresh"
+    );
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        // 리프레시 엔드포인트는 JwtRefreshTokenFilter에서만 처리
-        // FIXME: refresh Token 흐름인 요청 주소 변경 확인
-        return "/auth/token/refresh".equals(request.getRequestURI());
+        String path = request.getRequestURI();
+        return EXCLUDE_URLS.stream().anyMatch(path::startsWith);
     }
 
     @Override


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Security 필터 체인 구성 리팩터링 및 특정 경로에서 PreAuthHeaderFilter를 스킵하도록 설정을 개선했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- SecurityConfig
   - JwtRefreshTokenFilter를 ExceptionTranslationFilter 뒤에, PreAuthHeaderFilter를 그 다음에 배치하여 예외 처리 흐름과 필터 순서 수정
   - /error 및 /auth/token/refresh 경로를 .permitAll()로 추가하여 인증 없이 접근 가능하도록 설정

- PreAuthHeaderFilter
   - EXCLUDE_URLS에 .permitAll() 경로 추가
   - shouldNotFilter() 메서드를 구현하여 위 경로들에서는 인증 컨텍스트 설정 과정을 스킵

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- permitAll인 요청 주소 변경 시 SecurityConfig filterChain과 PreAuthHeaderFilter EXCLUDE_URLS 업데이트 필요