### PR TITLE
Feat/auth admin maintenance: adminId 설계 변경에 따른 로직 추가 및 수정, 주석 정리, 이메일 인증 redirect 수정

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/account/entity/AuthAccount.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/entity/AuthAccount.java
@@ -61,6 +61,10 @@ public class AuthAccount {
     @Column(name = "partner_id")
     private Long partnerId;
 
+    // admin_service 연동 ID (auth_account의 admin_id)
+    @Column(name = "admin_id")
+    private Long adminId;
+
     // 계정 상태 (ACTIVE / WAITING_PROFILE_COMPLETION / WITHDRAWN / WAITING_EMAIL_VERIFICATION / PENDING_ADMIN_APPROVAL)
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 30, nullable = false)

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/entity/WithdrawalHistory.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/entity/WithdrawalHistory.java
@@ -62,6 +62,10 @@ public class WithdrawalHistory {
     @Column(name = "partner_id")
     private Long partnerId;
 
+    // admin_service 연동 ID (auth_account의 admin_id)
+    @Column(name = "admin_id")
+    private Long adminId;
+
     // USER, ADMIN, PARTNER의 보관 필수인 최소 프로필 정보
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "profile_snapshot", columnDefinition = "jsonb", nullable = false)

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
@@ -35,6 +35,14 @@ public interface AccountService {
     AuthAccount save(AuthAccount account);
 
     /**
+     * 계정에 연결된 adminId 업데이트
+     *
+     * @param accountId 계정의 UUID
+     * @param adminId 어드민 서비스의 식별자
+     */
+    void updateAdminId(UUID accountId, Long adminId);
+
+    /**
      * 계정에 연결된 partnerId 업데이트
      *
      * @param accountId 계정의 UUID

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
@@ -36,6 +36,15 @@ class AccountServiceImpl implements AccountService {
 
     @Override
     @Transactional
+    public void updateAdminId(UUID accountId, Long adminId) {
+        AuthAccount account = authAccountRepository.findById(accountId)
+                .orElseThrow(() -> new EntityNotFoundException("Account(" + accountId + ") not found"));
+
+        account.setAdminId(adminId);
+    }
+
+    @Override
+    @Transactional
     public void updatePartnerId(UUID accountId, Long partnerId) {
         AuthAccount account = authAccountRepository.findById(accountId)
                 .orElseThrow(() -> new EntityNotFoundException("Account(" + accountId + ") not found"));

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/controller/AdminAuthController.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/controller/AdminAuthController.java
@@ -57,7 +57,7 @@ public class AdminAuthController {
 
         ApiResponse<JwtResponse> response = ApiResponse.<JwtResponse>builder()
                 .code(0)
-                .message("OK")
+                .message("Admin login successful")
                 .data(tokens)
                 .build();
 

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/request/AdminProfileRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/request/AdminProfileRequest.java
@@ -2,8 +2,6 @@ package ready_to_marry.authservice.admin.dto.request;
 
 import lombok.*;
 
-import java.util.UUID;
-
 /**
  * 관리자 프로필 저장 INTERNAL API 요청시 보낼 DTO
  *
@@ -15,9 +13,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class AdminProfileRequest {
-    // 계정 고유 ID: auth_account의 account_id
-    private UUID accountId;
-
     // 관리자 이름
     private String name;
 

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/service/AdminAuthService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/service/AdminAuthService.java
@@ -91,7 +91,7 @@ public class AdminAuthService {
         // 6) ADMIN SERVICE에 요청 (INTERNAL API) -> admin_profile(adminDB)에 저장
         // TODO: INTERNAL API 호출 로직 추가
         // TODO: INTERNAL API 호출 에러 시 처리 로직 추가
-        // FIXME: INTERNAL API 호출 결과에서 가져오는 partnerId로 변경 (임시 코드)
+        // FIXME: INTERNAL API 호출 결과에서 가져오는 adminId로 변경 (임시 코드)
         Random rnd = new Random();
         Long adminId = rnd.nextLong();
 

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
@@ -38,7 +38,7 @@ public interface PartnerApprovalService {
      * @throws InfrastructureException  DB_RETRIEVE_FAILURE
      * @throws InfrastructureException  DB_SAVE_FAILURE
      * @throws InfrastructureException  DB_DELETE_FAILURE
-     * @throws InfrastructureException JSON_SERIALIZATION_FAILURE
+     * @throws InfrastructureException  JSON_SERIALIZATION_FAILURE
      */
     void rejectPartner(UUID accountId, PartnerRejectionRequest request);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/jwt/JwtClaims.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/jwt/JwtClaims.java
@@ -21,5 +21,6 @@ public class JwtClaims {
     private Long partnerId;
 
     // 관리자(ADMIN)일 때만 사용
+    private Long adminId;
     private String adminRole;
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/jwt/JwtTokenProvider.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/jwt/JwtTokenProvider.java
@@ -53,6 +53,7 @@ public class JwtTokenProvider {
             builder.claim("partnerId", claims.getPartnerId());
         }
         if ("ADMIN".equals(claims.getRole()) && claims.getAdminRole() != null) {
+            builder.claim("adminId", claims.getAdminId());
             builder.claim("adminRole", claims.getAdminRole());
         }
 

--- a/AuthService/src/main/java/ready_to_marry/authservice/partner/controller/PartnerAuthWebController.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/partner/controller/PartnerAuthWebController.java
@@ -41,7 +41,7 @@ public class PartnerAuthWebController {
             attrs.addFlashAttribute("status", "error");
         }
 
-        return "redirect:/auth/partners/verify/result";
+        return "redirect:/auth-service/auth/partners/verify/result";
     }
 
     /**


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 어드민 도메인 ID(adminId) 설계 변경에 따른 관련 로직 추가 및 수정, 불필요 필드 제거, 주석 정리, 이메일 인증 redirect 경로 수정 사항을 반영했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- adminId 설계 변경에 따른 관련 로직 추가 및 수정
   - AuthAccount 엔티티에 adminId 필드 추가
   - WithdrawalHistory 엔티티에 adminId 필드 추가
   - AccountService 인터페이스 및 구현체에 updateAdminId(UUID, Long) 메서드 선언 및 구현
   - AdminAuthService.registerAdmin에서 임시 랜덤값으로 생성한 adminId를 저장하도록 updateAdminId 호출 로직 추가
   - AdminAuthService.login에서 JWT Access Token 발급 시 adminId 클레임 포함
   - JwtClaims에 private Long adminId 필드 추가
   - JwtTokenProvider에서 관리자 권한 발급 시 adminId 클레임을 토큰에 포함하도록 로직 보강

- 필드 제거 및 리팩토링
   - AdminProfileRequest 클래스에서 더 이상 사용되지 않는 accountId 속성 및 관련 주석 삭제
   - AdminAuthController.login의 성공 메시지 값을 개선
   - PartnerApprovalService.rejectPartner 주석 줄간격을 정리하여 가독성 개선

- 이메일 인증 redirect 경로 수정
   - PartnerAuthWebController.verifyEmail에서 반환되는 리디렉트 URL을
"/auth/partners/verify/result" → "/auth-service/auth/partners/verify/result"로 변경

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- 어드민 프로필 정보를 저장하는 INTERNAL API 호출 결과에서 가져오는 adminId로 변경 필요 (현재: 임시 코드)