### PR TITLE
Fix/disable mail healthcheck: 메일 헬스체크 비활성화 설정 추가

### DIFF
--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -21,6 +21,7 @@ spring.data.redis.sentinel.password=${SPRING_DATA_REDIS_SENTINEL_PASSWORD}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
 # /actuator/health
+management.health.mail.enabled=false
 management.endpoints.web.exposure.include=health
 
 # Eureka


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Actuator 환경에서 SMTP 메일 헬스체크 시 발생하는 로그인 시도 초과 오류를 방지하기 위해 메일 헬스체크를 비활성화하도록 설정을 추가했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [X] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- application.properties에 `management.health.mail.enabled=false` 추가하여 메일 헬스체크를 비활성화
- 기존에는 Actuator가 주기적으로 SMTP 서버 연결을 시도하며 헬스체크를 수행했으나, 과도한 로그인 시도 실패(“Too many login attempts”)로 서비스가 예기치 않게 경고를 발생시키는 문제 존재 
- 해당 설정을 통해 Actuator가 더 이상 SMTP 헬스체크를 수행하지 않도록 하여, 불필요한 인증 오류를 방지

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
- 메일 헬스체크를 완전히 비활성화했으므로, 메일 서비스 상태 모니터링이 필요할 경우 다른 방법으로 별도 확인이 필요 