### PR TITLE
Fix/partner email verify path: 파트너 이메일 인증 링크 생성 시 하드 코딩 오류 수정

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/partner/config/AuthPartnerProperties.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/partner/config/AuthPartnerProperties.java
@@ -1,0 +1,18 @@
+package ready_to_marry.authservice.partner.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * application.properties의 auth.partner.* 설정을 바인딩
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "auth.partner")
+public class AuthPartnerProperties {
+    // Partner 이메일 인증(verify) 경로
+    private String verifyPath;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/partner/service/PartnerAuthServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/partner/service/PartnerAuthServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ready_to_marry.authservice.account.entity.AuthAccount;
 import ready_to_marry.authservice.account.service.AccountService;
-import ready_to_marry.authservice.common.config.AppProperties;
 import ready_to_marry.authservice.common.dto.response.JwtResponse;
 import ready_to_marry.authservice.common.enums.AccountStatus;
 import ready_to_marry.authservice.common.enums.AuthMethod;
@@ -21,6 +20,7 @@ import ready_to_marry.authservice.common.jwt.JwtClaims;
 import ready_to_marry.authservice.common.jwt.JwtProperties;
 import ready_to_marry.authservice.common.jwt.JwtTokenProvider;
 import ready_to_marry.authservice.common.util.MaskingUtil;
+import ready_to_marry.authservice.partner.config.AuthPartnerProperties;
 import ready_to_marry.authservice.partner.dto.request.PartnerLoginRequest;
 import ready_to_marry.authservice.partner.dto.request.PartnerProfileRequest;
 import ready_to_marry.authservice.partner.dto.request.PartnerSignupRequest;
@@ -29,7 +29,6 @@ import ready_to_marry.authservice.token.service.RefreshTokenService;
 import ready_to_marry.authservice.token.service.VerificationTokenService;
 
 import java.time.OffsetDateTime;
-import java.util.Random;
 import java.util.UUID;
 
 @Slf4j
@@ -40,7 +39,7 @@ public class PartnerAuthServiceImpl implements PartnerAuthService {
     private final VerificationTokenService verificationTokenService;
     private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
-    private final AppProperties appProperties;
+    private final AuthPartnerProperties authPartnerProperties;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final JwtProperties jwtProperties;
@@ -158,7 +157,7 @@ public class PartnerAuthServiceImpl implements PartnerAuthService {
         }
 
         // 8) 이메일 인증 메일 전송
-        String link = String.format("%s/auth/partners/verify?token=%s", appProperties.getUrlBase(), token);
+        String link = String.format("%s?token=%s", authPartnerProperties.getVerifyPath(), token);
         try {
             emailService.sendPartnerVerification(savedAccount.getLoginId(), link);
         } catch (MailException ex) {

--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -63,6 +63,9 @@ app.mail.templates.partner-rejected=partner-rejected.html
 # app.url.base: URL
 app.url-base=${APP_URL_BASE}
 
+# Partner verify path
+auth.partner.verify-path=${app.url-base}/auth-service/auth/partners/verify
+
 # PKCE state, verifier TTL
 auth.oauth.state-ttl=${AUTH_OAUTH_STATE_TTL:300s}
 


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 파트너 이메일 인증 링크 생성 로직이 하드 코딩되어 잘못된 URL이 생성되는 문제를 수정했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- application.properties에 auth.partner.verify-path 프로퍼티를 추가하여 이메일 인증 URL을 설정값으로 관리하도록 변경
- AuthPartnerProperties 클래스를 생성하여 auth.partner.verify-path 설정값을 바인딩
- PartnerAuthServiceImpl에서 이메일 인증 링크 생성 시 기존 하드 코딩(appProperties.getUrlBase() + "/auth/partners/verify) 대신 authPartnerProperties.getVerifyPath()를 사용하도록 수정

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
