### PR TITLE
fix: SocialUserInfo JsonCreator 로직 Naver ID 파싱 개선 onprem 브랜치에 반영

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/SocialUserInfo.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/social/dto/external/SocialUserInfo.java
@@ -1,9 +1,8 @@
 package ready_to_marry.authservice.social.dto.external;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 소셜 인증 서버로부터 사용자 정보를 조회할 때 사용하는 DTO
@@ -12,12 +11,30 @@ import lombok.NoArgsConstructor;
  * 응답으로 제공되는 사용자 고유 ID를 매핑
  */
 @Getter
-@NoArgsConstructor
 public class SocialUserInfo {
-    // 소셜 사용자 고유 ID
-    // - Kakao/Naver: "id"
-    // - Google:      "sub"
-    @JsonProperty("id")
-    @JsonAlias("sub")
-    private String id;
+    private final String id;
+
+    /**
+     * @JsonCreator를 붙인 생성자에서 JsonNode를 통째로 받아와서,
+     * 각 소셜 로그인 응답 형태에 따라 id를 직접 추출
+     */
+    @JsonCreator
+    public SocialUserInfo(JsonNode rootNode) {
+        String extractedId = null;
+
+        // 1) 네이버 응답: 최상위가 아니라 "response" 객체 내부에 "id"가 있음
+        if (rootNode.has("response") && rootNode.get("response").has("id")) {
+            extractedId = rootNode.get("response").get("id").asText();
+
+            // 2) 카카오(또는 네이버 일부 버전) 응답: 최상위에 바로 "id" 필드가 있음
+        } else if (rootNode.has("id")) {
+            extractedId = rootNode.get("id").asText();
+
+            // 3) 구글 응답: 최상위에 "sub" 필드가 있음
+        } else if (rootNode.has("sub")) {
+            extractedId = rootNode.get("sub").asText();
+        }
+
+        this.id = extractedId;
+    }
 }


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- dev 브랜치에서 onprem 브랜치로 버그 수정사항을 동기화했습니다.
- 특히, Naver 소셜 로그인 시 SocialUserInfo에서 response.id를 올바르게 파싱하도록 개선된 JsonCreator 로직이 포함되어 있습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- 기존 @JsonProperty/@JsonAlias 매핑만으로 Naver의 response.id를 찾지 못하던 문제 수정
- JsonNode 기반 @JsonCreator 생성자에서 우선 response.id를 추출하고, 없으면 최상위 id(Kakao) 또는 sub(Google)를 파싱하도록 분기 로직 구현

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
