### PR TITLE
Feat/auth user profile fcm integration: UserProfileCompletionRequest 및 내부 API 호출 로직에 fcmToken 추가

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
@@ -9,9 +9,9 @@ import lombok.*;
 import java.util.UUID;
 
 /**
- * 유저 프로필 등록 완료 요청 DTO
+ * 유저 프로필 + FCM 토큰 등록 완료 요청 DTO
  *
- * 소셜 로그인 후 추가로 받아야 할 사용자 프로필 정보
+ * 소셜 로그인 후 추가로 받아야 할 사용자 프로필 + FCM 토큰 정보
  */
 @Getter
 @Setter
@@ -32,4 +32,8 @@ public class UserProfileCompletionRequest {
     @NotBlank
     @Pattern(regexp = "^\\+?[0-9\\-]{1,20}$")
     private String phone;
+
+    // 유저 FCM 토큰(푸시 알림 허용 시에만 전달됨)
+    @Size(max = 255)
+    private String fcmToken;
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
@@ -3,9 +3,9 @@ package ready_to_marry.authservice.user.dto.request;
 import lombok.*;
 
 /**
- * 유저 프로필 저장 INTERNAL API 요청시 보낼 DTO
+ * 유저 프로필 등록 + FCM 토큰 등록 INTERNAL API 요청시 보낼 DTO
  *
- * 유저 소셜 로그인 후 유저 프로필 등록 완료 요청 시 클라이언트로부터 전달받을 정보 중 유저 프로필 저장에 필요한 정보
+ * 유저 소셜 로그인 후 유저 프로필 등록 완료 요청 시 클라이언트로부터 전달받을 정보 중 유저 프로필 등록 및 FCM 토큰 등록에 필요한 정보
  */
 @Getter
 @Setter
@@ -19,4 +19,7 @@ public class UserProfileRequest {
 
     // 유저 연락처
     private String phone;
+
+    // 유저 FCM 토큰(푸시 알림 허용 시에만 전달됨)
+    private String fcmToken;
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
@@ -47,7 +47,7 @@ public interface UserAuthService {
      * 6) Refresh Token Redis에 저장
      * 7) 최종 응답 DTO 반환
      *
-     * @param request                       프로필 완성 요청 DTO (accountId, 추가 정보)
+     * @param request                       유저 프로필 + FCM 토큰 등록 완료 요청 DTO (accountId, 추가 정보)
      * @return JwtResponse                  발급된 access/refresh 토큰 + expiresIn (만료 시간)
      * @throws BusinessException            ACCOUNT_NOT_FOUND
      * @throws BusinessException            PROFILE_ALREADY_COMPLETED

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
@@ -23,8 +23,6 @@ import ready_to_marry.authservice.token.service.RefreshTokenService;
 import ready_to_marry.authservice.user.dto.request.UserProfileCompletionRequest;
 import ready_to_marry.authservice.user.dto.request.UserProfileRequest;
 
-import java.util.Random;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -123,6 +121,7 @@ public class UserAuthServiceImpl implements UserAuthService {
         UserProfileRequest internalRequest = UserProfileRequest.builder()
                 .name(request.getName())
                 .phone(request.getPhone())
+                .fcmToken(request.getFcmToken())
                 .build();
 
         // 2)-2 USER SERVICE에 요청 (INTERNAL API) → user_profile(userDB)에 저장


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 소셜 로그인 후 프로필 완료 단계에서 클라이언트가 FCM 토큰을 함께 전달할 수 있도록 DTO와 서비스 로직을 확장했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- UserProfileCompletionRequest DTO 수정
   - fcmToken 필드를 추가하여, 프로필 완료 시 FCM 토큰을 등록 할 수 있도록 변경

- INTERNAL API 요청용 UserProfileRequest DTO 수정
   - 내부 서비스 호출 시 필요한 정보에 fcmToken을 포함시키도록 UserProfileRequest 클래스에 해당 필드를 추가 

- UserAuthService.completeUserProfile 주석 수정 

- UserAuthServiceImpl.completeUserProfile 로직 수정
   - 내부 API 호출 시 기존에 보내던 프로필 정보(name, phone) 외에, request.getFcmToken() 값을 함께 UserProfileRequest에 포함시키도록 변경

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
