### PR TITLE
feat: FCM 토큰 통합 및 관리자 승인 대기 파트너 목록 페이징 조회 기능 추가 onprem 브랜치에 반영

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/account/repository/AuthAccountRepository.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/repository/AuthAccountRepository.java
@@ -1,8 +1,12 @@
 package ready_to_marry.authservice.account.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ready_to_marry.authservice.account.entity.AuthAccount;
+import ready_to_marry.authservice.common.enums.AccountStatus;
+import ready_to_marry.authservice.common.enums.Role;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -19,4 +23,14 @@ public interface AuthAccountRepository extends JpaRepository<AuthAccount, UUID> 
      * @return Optional.empty()이면 미존재
      */
     Optional<AuthAccount> findByLoginId(String loginId);
+
+    /**
+     * 특정 역할이면서 특정 상태인 계정을 생성 시각 오름차순으로 페이징 조회
+     *
+     * @param role     조회할 계정의 역할 (예: PARTNER)
+     * @param status   조회할 계정의 상태 (예: PENDING_ADMIN_APPROVAL)
+     * @param pageable 페이징 정보
+     * @return 지정된 role과 status를 만족하며 createdAt 오름차순 정렬된 페이징 결과
+     */
+    Page<AuthAccount> findAllByRoleAndStatusOrderByCreatedAtAsc(Role role, AccountStatus status, Pageable pageable);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountService.java
@@ -1,7 +1,10 @@
 package ready_to_marry.authservice.account.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import ready_to_marry.authservice.account.entity.AuthAccount;
 import ready_to_marry.authservice.common.enums.AccountStatus;
+import ready_to_marry.authservice.common.enums.Role;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -73,4 +76,14 @@ public interface AccountService {
      * @param accountId 삭제할 계정의 UUID
      */
     void deleteById(UUID accountId);
+
+    /**
+     * 지정된 역할(role) + 상태(status)를 가진 계정을 생성 시각 오름차순으로 페이징 조회
+     *
+     * @param role 페이징 조회할 역할
+     * @param status 페이징 조회할 계정 상태
+     * @param pageable 페이징 정보
+     * @return 조회된 Page<AuthAccount>
+     */
+    Page<AuthAccount> findByRoleAndStatus(Role role, AccountStatus status, Pageable pageable);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/account/service/AccountServiceImpl.java
@@ -2,11 +2,14 @@ package ready_to_marry.authservice.account.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ready_to_marry.authservice.account.entity.AuthAccount;
 import ready_to_marry.authservice.account.repository.AuthAccountRepository;
 import ready_to_marry.authservice.common.enums.AccountStatus;
+import ready_to_marry.authservice.common.enums.Role;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -74,5 +77,11 @@ class AccountServiceImpl implements AccountService {
     @Transactional
     public void deleteById(UUID accountId) {
         authAccountRepository.deleteById(accountId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<AuthAccount> findByRoleAndStatus(Role role, AccountStatus status, Pageable pageable) {
+        return authAccountRepository.findAllByRoleAndStatusOrderByCreatedAtAsc(role, status, pageable);
     }
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/controller/AdminPartnerApprovalController.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/controller/AdminPartnerApprovalController.java
@@ -2,21 +2,25 @@ package ready_to_marry.authservice.admin.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import ready_to_marry.authservice.admin.dto.request.PartnerRejectionRequest;
+import ready_to_marry.authservice.admin.dto.response.PartnerPendingResponse;
 import ready_to_marry.authservice.admin.service.PartnerApprovalService;
+import ready_to_marry.authservice.common.dto.request.PagingRequest;
 import ready_to_marry.authservice.common.dto.response.ApiResponse;
+import ready_to_marry.authservice.common.dto.response.Meta;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
- * SUPER_ADMIN용 파트너 회원가입 승인·거부를 처리하는 컨트롤러
+ * 파트너 회원가입 승인·거부·조회를 처리하는 컨트롤러
  */
 @RestController
 @RequestMapping("/auth/admins/partners")
-@PreAuthorize("hasRole('SUPER_ADMIN')")
 @RequiredArgsConstructor
 public class AdminPartnerApprovalController {
     private final PartnerApprovalService partnerApprovalService;
@@ -28,6 +32,7 @@ public class AdminPartnerApprovalController {
      * @return 성공 시 code=0, data=null
      */
     @PostMapping("/{accountId}/approval")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
     public ResponseEntity<ApiResponse<Void>> approvePartner(@PathVariable UUID accountId) {
         partnerApprovalService.approvePartner(accountId);
 
@@ -48,6 +53,7 @@ public class AdminPartnerApprovalController {
      * @return 성공 시 code=0, data=null
      */
     @PostMapping("/{accountId}/rejection")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
     public ResponseEntity<ApiResponse<Void>> rejectPartner(@PathVariable UUID accountId, @Valid @RequestBody PartnerRejectionRequest request) {
         partnerApprovalService.rejectPartner(accountId, request);
 
@@ -55,6 +61,31 @@ public class AdminPartnerApprovalController {
                 .code(0)
                 .message("Partner rejected and deleted")
                 .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 관리자 승인 대기 중인 파트너 목록 페이징 조회
+     *
+     * @param pagingRequest 페이징 요청 정보 (page, size)
+     * @return 성공 시 code=0, data=관리자 승인 대기 중인 파트너 내역 페이징 결과 정보
+     */
+    @GetMapping("/pending")
+    public ResponseEntity<ApiResponse<List<PartnerPendingResponse>>> getPendingPartners(@Valid @ModelAttribute PagingRequest pagingRequest) {
+        Page<PartnerPendingResponse> page = partnerApprovalService.getPendingPartners(pagingRequest);
+
+        ApiResponse<List<PartnerPendingResponse>> response = ApiResponse.<List<PartnerPendingResponse>>builder()
+                .code(0)
+                .message("Pending partners retrieved successfully")
+                .data(page.getContent())
+                .meta(Meta.builder()
+                        .page(page.getNumber())
+                        .size(page.getSize())
+                        .totalElements(page.getTotalElements())
+                        .totalPages(page.getTotalPages())
+                        .build())
                 .build();
 
         return ResponseEntity.ok(response);

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/response/PartnerPendingResponse.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/response/PartnerPendingResponse.java
@@ -1,0 +1,40 @@
+package ready_to_marry.authservice.admin.dto.response;
+
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 관리자 승인 대기 중인 파트너 계정 및 프로필 정보를 한 건씩 담는 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartnerPendingResponse {
+    // auth_account의 PK
+    private UUID accountId;
+
+    // 계정 생성 시각
+    private OffsetDateTime createdAt;
+
+    // 회사 대표자 이름
+    private String name;
+
+    // 회사 이름
+    private String companyName;
+
+    // 회사 주소
+    private String address;
+
+    // 담당자 연락처
+    private String phone;
+
+    // 회사 연락처
+    private String companyNum;
+
+    // 사업자번호
+    private String businessNum;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/response/PartnerProfileAll.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/dto/response/PartnerProfileAll.java
@@ -1,0 +1,33 @@
+package ready_to_marry.authservice.admin.dto.response;
+
+import lombok.*;
+
+/**
+ * 관리자 승인 대기 중인 파트너 계정 목록 페이징 조회 시점에 조회할 파트너 프로필 DTO
+ *
+ * 리자 승인 대기 중인 파트너 계정 목록 페이징 조회 시 INTERNAL API 로부터 전달받을 프로필 정보
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartnerProfileAll {
+    // 회사 대표자 이름
+    private String name;
+
+    // 회사 이름
+    private String companyName;
+
+    // 회사 주소
+    private String address;
+
+    // 담당자 연락처
+    private String phone;
+
+    // 회사 연락처
+    private String companyNum;
+
+    // 사업자번호
+    private String businessNum;
+}

--- a/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/admin/service/PartnerApprovalService.java
@@ -1,13 +1,16 @@
 package ready_to_marry.authservice.admin.service;
 
+import org.springframework.data.domain.Page;
 import ready_to_marry.authservice.admin.dto.request.PartnerRejectionRequest;
+import ready_to_marry.authservice.admin.dto.response.PartnerPendingResponse;
+import ready_to_marry.authservice.common.dto.request.PagingRequest;
 import ready_to_marry.authservice.common.exception.BusinessException;
 import ready_to_marry.authservice.common.exception.InfrastructureException;
 
 import java.util.UUID;
 
 /**
- * SUPER_ADMIN용 파트너 승인·거부 비즈니스 로직을 제공하는 서비스 인터페이스
+ * 파트너 승인·거부·조회 비즈니스 로직을 제공하는 서비스 인터페이스
  */
 public interface PartnerApprovalService {
     /**
@@ -41,4 +44,17 @@ public interface PartnerApprovalService {
      * @throws InfrastructureException  JSON_SERIALIZATION_FAILURE
      */
     void rejectPartner(UUID accountId, PartnerRejectionRequest request);
+
+    /**
+     * PENDING_ADMIN_APPROVAL 상태인 파트너 계정들을 생성 시각 오름차순으로 페이징 조회
+     * 1) 페이징 요청 정보 생성
+     * 2) 관리자 승인 대기 중인 파트너 계정 목록을 생성 시각 기준으로 오름차순 정렬하여 조회
+     * 3) 각 AuthAccount마다 PARTNER SERVICE에 요청 (INTERNAL API) -> partner_profile(partnerDB)에서 조회
+     * 4) AuthAccount + PartnerProfileAll → PartnerPendingResponse 매핑
+     *
+     * @param pagingRequest                             페이징 요청 정보 (page, size)
+     * @return Page<PartnerPendingResponse>             조회된 계정 목록 페이징 결과
+     * @throws InfrastructureException                  DB_RETRIEVE_FAILURE
+     */
+    Page<PartnerPendingResponse> getPendingPartners(PagingRequest pagingRequest);
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/dto/request/PagingRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/dto/request/PagingRequest.java
@@ -1,6 +1,8 @@
 package ready_to_marry.authservice.common.dto.request;
 
 import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 리스트 조회 시 페이징 요청 정보 DTO
@@ -8,6 +10,8 @@ import jakarta.validation.constraints.Min;
  * - page : 조회할 페이지 번호 (0부터 시작)
  * - size : 한 페이지당 조회할 데이터 개수 (최소 1)
  */
+@Getter
+@Setter
 public class PagingRequest {
 
     // 조회할 페이지 번호 (0부터 시작)

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileCompletionRequest.java
@@ -9,9 +9,9 @@ import lombok.*;
 import java.util.UUID;
 
 /**
- * 유저 프로필 등록 완료 요청 DTO
+ * 유저 프로필 + FCM 토큰 등록 완료 요청 DTO
  *
- * 소셜 로그인 후 추가로 받아야 할 사용자 프로필 정보
+ * 소셜 로그인 후 추가로 받아야 할 사용자 프로필 + FCM 토큰 정보
  */
 @Getter
 @Setter
@@ -32,4 +32,8 @@ public class UserProfileCompletionRequest {
     @NotBlank
     @Pattern(regexp = "^\\+?[0-9\\-]{1,20}$")
     private String phone;
+
+    // 유저 FCM 토큰(푸시 알림 허용 시에만 전달됨)
+    @Size(max = 255)
+    private String fcmToken;
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/dto/request/UserProfileRequest.java
@@ -3,9 +3,9 @@ package ready_to_marry.authservice.user.dto.request;
 import lombok.*;
 
 /**
- * 유저 프로필 저장 INTERNAL API 요청시 보낼 DTO
+ * 유저 프로필 등록 + FCM 토큰 등록 INTERNAL API 요청시 보낼 DTO
  *
- * 유저 소셜 로그인 후 유저 프로필 등록 완료 요청 시 클라이언트로부터 전달받을 정보 중 유저 프로필 저장에 필요한 정보
+ * 유저 소셜 로그인 후 유저 프로필 등록 완료 요청 시 클라이언트로부터 전달받을 정보 중 유저 프로필 등록 및 FCM 토큰 등록에 필요한 정보
  */
 @Getter
 @Setter
@@ -19,4 +19,7 @@ public class UserProfileRequest {
 
     // 유저 연락처
     private String phone;
+
+    // 유저 FCM 토큰(푸시 알림 허용 시에만 전달됨)
+    private String fcmToken;
 }

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthService.java
@@ -47,7 +47,7 @@ public interface UserAuthService {
      * 6) Refresh Token Redis에 저장
      * 7) 최종 응답 DTO 반환
      *
-     * @param request                       프로필 완성 요청 DTO (accountId, 추가 정보)
+     * @param request                       유저 프로필 + FCM 토큰 등록 완료 요청 DTO (accountId, 추가 정보)
      * @return JwtResponse                  발급된 access/refresh 토큰 + expiresIn (만료 시간)
      * @throws BusinessException            ACCOUNT_NOT_FOUND
      * @throws BusinessException            PROFILE_ALREADY_COMPLETED

--- a/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/user/service/UserAuthServiceImpl.java
@@ -23,8 +23,6 @@ import ready_to_marry.authservice.token.service.RefreshTokenService;
 import ready_to_marry.authservice.user.dto.request.UserProfileCompletionRequest;
 import ready_to_marry.authservice.user.dto.request.UserProfileRequest;
 
-import java.util.Random;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -123,6 +121,7 @@ public class UserAuthServiceImpl implements UserAuthService {
         UserProfileRequest internalRequest = UserProfileRequest.builder()
                 .name(request.getName())
                 .phone(request.getPhone())
+                .fcmToken(request.getFcmToken())
                 .build();
 
         // 2)-2 USER SERVICE에 요청 (INTERNAL API) → user_profile(userDB)에 저장


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- onprem 환경에 다음 두 가지 주요 기능을 배포합니다
   - 소셜 로그인 프로필 완료 시 FCM 토큰을 함께 전송·등록하도록 Auth 서비스 로직 확장
   - 관리자 승인 대기 파트너 목록을 페이징 조회하는 기능 추가

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
-  FCM 통합
   - 소셜 로그인 완료 후 프로필 등록 요청에 fcmToken이 제공되면, 내부 API로 해당 토큰을 함께 전송하여 저장

- 관리자 승인 대기 파트너 목록 페이징 조회
   - DB에서 PARTNER+PENDING_ADMIN_APPROVAL 계정만 조회하도록 Repository 확장
   - 서비스 계층에서 페이징 처리 후 각 계정의 프로필을 Partner Client로부터 가져와 PartnerPendingResponse로 변환
   
## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
