### PR TITLE
feat: Micrometer Prometheus 레지스트리 및 Actuator 설정 활성화

### DIFF
--- a/AuthService/build.gradle
+++ b/AuthService/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Micrometer-Registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Retry & AOP
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -20,9 +20,12 @@ spring.data.redis.sentinel.nodes=${SPRING_DATA_REDIS_SENTINEL_NODES}
 spring.data.redis.sentinel.password=${SPRING_DATA_REDIS_SENTINEL_PASSWORD}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
-# /actuator/health
+# /actuator
 management.health.mail.enabled=false
-management.endpoints.web.exposure.include=health
+management.endpoints.web.exposure.include=*
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.base-path=/actuator
+management.prometheus.metrics.export.enabled=true
 
 # Eureka
 spring.application.name=auth-service


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Micrometer-Prometheus 레지스트리 의존성을 추가하고 Actuator 엔드포인트를 전체 노출하며 Prometheus 메트릭 수집을 활성화했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- micrometer-registry-prometheus 의존성 추가
- 모든 Actuator 엔드포인트 노출
- /actuator 기본 경로 설정
- Prometheus 메트릭 엔드포인트 활성화

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
