### PR TITLE
feat: Actuator 엔드포인트 최소 노출 및 보안 필터 예외 처리

### DIFF
--- a/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/config/SecurityConfig.java
@@ -50,6 +50,14 @@ public class SecurityConfig {
                         // 스프링 에러 핸들러 경로는 인증 없이 허용
                         .requestMatchers("/error").permitAll()
 
+                        // Actuator 주요 엔드포인트(prometheus, health, info, metrics)를 인증 없이 허용
+                        .requestMatchers(
+                                "/actuator/prometheus",
+                                "/actuator/health",
+                                "/actuator/info",
+                                "/actuator/metrics"
+                        ).permitAll()
+
                         // 인증 없이 접근 가능한 Auth 서비스 엔드포인트
                         .requestMatchers(
                                 // FIXME: permitAll인 요청 주소 변경 확인
@@ -61,8 +69,7 @@ public class SecurityConfig {
                                 "/auth/partners/verify",
                                 "/auth/partners/verify/result",
                                 "/auth/admins/login",
-                                "/auth/token/refresh",
-                                "/actuator/health"
+                                "/auth/token/refresh"
                         ).permitAll()
 
                         // 그 외 모든 요청은 인증 필요

--- a/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
+++ b/AuthService/src/main/java/ready_to_marry/authservice/common/security/PreAuthHeaderFilter.java
@@ -29,6 +29,11 @@ public class PreAuthHeaderFilter extends OncePerRequestFilter {
     // 스킵할 URL 패턴
     private static final List<String> EXCLUDE_URLS = List.of(
             // FIXME: permitAll인 요청 주소 변경 확인
+            "/error",
+            "/actuator/prometheus",
+            "/actuator/health",
+            "/actuator/info",
+            "/actuator/metrics",
             "/auth/oauth2/authorize/**",
             "/auth/oauth2/callback/**",
             "/auth/users/profile/complete",

--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -22,7 +22,7 @@ spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
 # /actuator
 management.health.mail.enabled=false
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.base-path=/actuator
 management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Actuator 엔드포인트 중 최소만 노출하고, Spring Security 필터 체인에서 해당 경로를 예외 처리하여 해당 엔드포인트가 원활히 동작하도록 개선합니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- application.properties
   - management.endpoints.web.exposure.include를 * → health,info,metrics,prometheus로 변경하여 불필요한 엔드포인트 노출 최소화

- PreAuthHeaderFilter
   - EXCLUDE_URLS 목록에 /actuator/prometheus, /actuator/health, /actuator/info, /actuator/metrics, /error 추가

- SecurityConfig
   - /actuator/prometheus, /actuator/health, /actuator/info, /actuator/metrics 경로에 대해 permitAll() 처리하여 인증·인가 예외 지정

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
